### PR TITLE
Removed notices of Reactor from the documentation.

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -10,10 +10,6 @@
 //! internal buffer has pending bytes. The same socket is ready to perform a
 //! write when its write buffer is not full.
 //!
-//! The `Readiness` trait represents this concept. The `Readiness` trait also
-//! acts as a marker trait to denotate types which are *Tokio aware*. A Tokio
-//! aware type is able to observe usage and signal interest to the `Reactor`.
-//!
 //! In the case of `TcpStream`, the Tokio aware TCP socket, when
 //! `TcpStream::try_read` is called and `Ok(None)` is returned, read interest
 //! is automatically registered with the reactor and associated with the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,15 +11,6 @@
 //!
 //! The service trait is decoupled from any notion of a runtime.
 //!
-//! # Reactor
-//!
-//! The Tokio Reactor is a lightweight, event driven, task scheduler. It
-//! accepts tasks, which are small units of work and schedules them for
-//! execution when their dependent I/O sources (TCP sockets, timers, etc...)
-//! are ready.
-//!
-//! The reactor and task exist in the `reactor` module.
-//!
 //! # Protocol building blocks
 //!
 //! Tokio aims to provide all the pieces necessary for rapidly developing

--- a/src/proto/pipeline/client.rs
+++ b/src/proto/pipeline/client.rs
@@ -9,10 +9,6 @@ use Service;
 use super::{pipeline, Error, Message, Transport, NewTransport};
 
 /// Client `Service` for the pipeline protocol.
-///
-/// Initiated requests are sent to the client pipeline task running on the
-/// Reactor where they are processed. The response is returned by completing
-/// the future.
 pub struct Client<Req, Resp, ReqBody, E>
     where Req: Send + 'static,
           Resp: Send + 'static,


### PR DESCRIPTION
I figured since the Reactor module was removed in https://github.com/tokio-rs/tokio-proto/pull/27 that we should probably edit the documentation to reflect this. Right now, I just removed any comments that had `Reactor` in them. New documentation for how `Client` and `Readiness` act should probably be provided.