### PR TITLE
Replace custom variants with option

### DIFF
--- a/src/proto/pipeline/pipeline.rs
+++ b/src/proto/pipeline/pipeline.rs
@@ -242,7 +242,7 @@ impl<S, T, E> Pipeline<S, T>
     fn write_in_message(&mut self, message: Result<Message<S::InMsg, S::InBodyStream>, S::Error>) -> io::Result<()> {
         trace!("write_in_message");
         match message {
-            Ok(Message::WithoutBody(val)) => {
+            Ok(Message(val, body)) => {
                 trace!("got in_flight value with body");
                 try!(self.transport.write(Frame::Message(val)));
 
@@ -250,17 +250,7 @@ impl<S, T, E> Pipeline<S, T>
                 assert!(self.in_body.is_none());
 
                 // Track the response body
-                self.in_body = None;
-            }
-            Ok(Message::WithBody(val, body)) => {
-                trace!("got in_flight value with body");
-                try!(self.transport.write(Frame::Message(val)));
-
-                // TODO: don't panic maybe if this isn't true?
-                assert!(self.in_body.is_none());
-
-                // Track the response body
-                self.in_body = Some(body);
+                self.in_body = body;
             }
             Err(e) => {
                 trace!("got in_flight error");

--- a/test/test_proto/test_pipeline_client.rs
+++ b/test/test_proto/test_pipeline_client.rs
@@ -27,7 +27,7 @@ fn test_ping_pong_close() {
     run(|mock, service| {
         mock.allow_write();
 
-        let pong = service.call(pipeline::Message::WithoutBody("ping"));
+        let pong = service.call(pipeline::Message("ping", None));
         assert_eq!("ping", mock.next_write().unwrap_msg());
 
         mock.send(pipeline::Frame::Message("pong"));
@@ -46,7 +46,7 @@ fn test_response_ready_before_request_sent() {
 
         support::sleep_ms(20);
 
-        let pong = service.call(pipeline::Message::WithoutBody("ping"));
+        let pong = service.call(pipeline::Message("ping", None));
 
         assert_eq!("pong", pong.wait().unwrap());
     });
@@ -58,7 +58,7 @@ fn test_streaming_request_body() {
         let (mut tx, rx) = stream::channel();
 
         mock.allow_write();
-        let pong = service.call(pipeline::Message::WithBody("ping", rx));
+        let pong = service.call(pipeline::Message("ping", Some(rx)));
 
         assert_eq!("ping", mock.next_write().unwrap_msg());
 

--- a/test/test_proto/test_pipeline_client.rs
+++ b/test/test_proto/test_pipeline_client.rs
@@ -30,7 +30,7 @@ fn test_ping_pong_close() {
         let pong = service.call(pipeline::Message("ping", None));
         assert_eq!("ping", mock.next_write().unwrap_msg());
 
-        mock.send(pipeline::Frame::Message("pong"));
+        mock.send(pipeline::Frame::Message("pong", None));
         assert_eq!("pong", pong.wait().unwrap());
 
         mock.send(pipeline::Frame::Done);
@@ -42,7 +42,7 @@ fn test_ping_pong_close() {
 #[ignore]
 fn test_response_ready_before_request_sent() {
     run(|mock, service| {
-        mock.send(pipeline::Frame::Message("pong"));
+        mock.send(pipeline::Frame::Message("pong", None));
 
         support::sleep_ms(20);
 
@@ -74,7 +74,7 @@ fn test_streaming_request_body() {
         drop(tx);
         assert_eq!(None, mock.next_write().unwrap_body());
 
-        mock.send(pipeline::Frame::Message("pong"));
+        mock.send(pipeline::Frame::Message("pong", None));
         assert_eq!("pong", pong.wait().unwrap());
 
         mock.send(pipeline::Frame::Done);

--- a/test/test_proto/test_pipeline_server.rs
+++ b/test/test_proto/test_pipeline_server.rs
@@ -409,12 +409,12 @@ fn channel<T>() -> (Arc<Mutex<mpsc::Sender<T>>>, mpsc::Receiver<T>) {
 }
 
 fn msg(msg: Msg) -> OutFrame {
-    Frame::Message(Message(msg, None))
+    Frame::Message(Message(msg, None), None)
 }
 
 fn msg_with_body(msg: Msg) -> OutFrame {
     let (tx, rx) = stream::channel();
-    Frame::MessageWithBody(Message(msg, Some(rx)), tx)
+    Frame::Message(Message(msg, Some(rx)), Some(tx))
 }
 
 /// Setup a reactor running a pipeline::Server with the given service and a


### PR DESCRIPTION
The `pipeline::Message` and `pipeline::Frame` types encodes the presence of a body using a separate enum variant. This forces users of this type to match on the presence of the body even when they don't care about it. By using an `Option` instead we simplify the match clauses, and we can leverage stdlib methods such as `Option::map`. As a bonus we get rid of an unsafe code block.
