### PR TITLE
Update futures version to match the other repos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rand = "0.3.14"
 smallvec = "0.2.0"
 
 bytes = { git = "https://github.com/carllerche/bytes" }
-futures = { git = "https://github.com/alexcrichton/futures-rs" }
+futures = "0.1"
 tokio-core = { git = "https://github.com/tokio-rs/tokio-core" }
 tokio-service = { git = "https://github.com/tokio-rs/tokio-service" }
 


### PR DESCRIPTION
Currently it doesn't compile, as futures have different versions across tokio-core and tokio-service and here.