### PR TITLE
Improvements to tokio-proto

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,45 @@
+use std::{error, fmt, io};
+
+/// Error returned as an Error frame or an `io::Error` that occurerred during
+/// normal processing of the Transport
+#[derive(Debug)]
+pub enum Error<E> {
+    /// Transport frame level error
+    Transport(E),
+    /// I/O level error
+    Io(io::Error),
+}
+
+impl<E: fmt::Display> fmt::Display for Error<E> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Transport(ref e) => fmt::Display::fmt(e, fmt),
+            Error::Io(ref e) => fmt::Display::fmt(e, fmt),
+        }
+    }
+}
+
+impl<E: error::Error> error::Error for Error<E> {
+    fn description(&self) -> &str {
+        match *self {
+            Error::Transport(ref e) => error::Error::description(e),
+            Error::Io(ref e) => error::Error::description(e),
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::Transport(ref e) => error::Error::cause(e),
+            Error::Io(ref e) => error::Error::cause(e),
+        }
+    }
+}
+
+impl From<Error<io::Error>> for io::Error {
+    fn from(err: Error<io::Error>) -> Self {
+        match err {
+            Error::Transport(e) |
+            Error::Io(e) => e,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,9 @@ pub mod server;
 mod error;
 mod framing;
 mod io;
+mod message;
 
 pub use error::Error;
 pub use framing::{Framed, Parse, Serialize};
 pub use io::{TryRead, TryWrite};
+pub use message::Message;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,10 @@ pub mod multiplex;
 pub mod pipeline;
 pub mod server;
 
+mod error;
 mod framing;
 mod io;
 
+pub use error::Error;
 pub use framing::{Framed, Parse, Serialize};
 pub use io::{TryRead, TryWrite};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod error;
 mod framing;
 mod io;
 mod message;
+mod sender;
 
 pub use error::Error;
 pub use framing::{Framed, Parse, Serialize};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,15 @@
 #![deny(warnings, missing_docs)]
 
 extern crate bytes;
-extern crate futures;
 extern crate slab;
 extern crate take;
 extern crate rand;
 extern crate smallvec;
 extern crate tokio_core;
 extern crate tokio_service;
+
+#[macro_use]
+extern crate futures;
 
 #[macro_use]
 extern crate log;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,72 @@
+use std::{cmp, fmt, ops};
+
+/// Message sent and received from a multiplexed service
+pub enum Message<T, B> {
+    /// Has no associated streaming body
+    WithoutBody(T),
+    /// Has associated streaming body
+    WithBody(T, B),
+}
+
+impl<T, B> Message<T, B> {
+    /// If the `Message` value has an associated body stream, return it. The
+    /// original `Message` value will then become a `WithoutBody` variant.
+    pub fn take_body(&mut self) -> Option<B> {
+        use std::ptr;
+
+        // unfortunate that this is unsafe, but I think it is preferable to add
+        // a little bit of unsafe code instead of adding a useless variant to
+        // Message.
+        unsafe {
+            match ptr::read(self as *const Message<T, B>) {
+                m @ Message::WithoutBody(..) => {
+                    ptr::write(self as *mut Message<T, B>, m);
+                    None
+                }
+                Message::WithBody(m, b) => {
+                    ptr::write(self as *mut Message<T, B>, Message::WithoutBody(m));
+                    Some(b)
+                }
+            }
+        }
+    }
+}
+
+impl<T, B> cmp::PartialEq<T> for Message<T, B>
+    where T: cmp::PartialEq
+{
+    fn eq(&self, other: &T) -> bool {
+        (**self).eq(other)
+    }
+}
+
+impl<T, B> ops::Deref for Message<T, B> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        match *self {
+            Message::WithoutBody(ref v) => v,
+            Message::WithBody(ref v, _) => v,
+        }
+    }
+}
+
+impl<T, B> ops::DerefMut for Message<T, B> {
+    fn deref_mut(&mut self) -> &mut T {
+        match *self {
+            Message::WithoutBody(ref mut v) => v,
+            Message::WithBody(ref mut v, _) => v,
+        }
+    }
+}
+
+impl<T, B> fmt::Debug for Message<T, B>
+    where T: fmt::Debug
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Message::WithoutBody(ref v) => write!(fmt, "Message::WithoutBody({:?})", v),
+            Message::WithBody(ref v, _) => write!(fmt, "Message::WithBody({:?}, ...)", v),
+        }
+    }
+}

--- a/src/multiplex/mod.rs
+++ b/src/multiplex/mod.rs
@@ -72,15 +72,6 @@ pub enum Message<T, B = Empty<(), ()>> {
     WithBody(T, B),
 }
 
-/// Error returned as an Error frame or an `io::Error` that occurerred during
-/// normal processing of the Transport
-pub enum Error<E> {
-    /// Transport frame level error
-    Transport(E),
-    /// I/O level error
-    Io(io::Error),
-}
-
 /// A specialization of `Service` supporting the requirements of server
 /// pipelined services
 ///
@@ -413,14 +404,5 @@ impl<F, T> NewTransport for Take<F>
 
     fn new_transport(&self) -> io::Result<T> {
         self.take()()
-    }
-}
-
-impl From<Error<io::Error>> for io::Error {
-    fn from(err: Error<io::Error>) -> Self {
-        match err {
-            Error::Transport(e) |
-            Error::Io(e) => e,
-        }
     }
 }

--- a/src/multiplex/multiplex.rs
+++ b/src/multiplex/multiplex.rs
@@ -1,4 +1,5 @@
-use super::{Frame, Message, Error, RequestId, Transport};
+use {Error};
+use super::{Frame, Message, RequestId, Transport};
 use super::frame_buf::{FrameBuf, FrameDeque};
 use futures::{Future, Poll, Async};
 use futures::stream::{Stream};

--- a/src/multiplex/multiplex.rs
+++ b/src/multiplex/multiplex.rs
@@ -1,5 +1,5 @@
-use {Error};
-use super::{Frame, Message, RequestId, Transport};
+use {Error, Message};
+use super::{Frame, RequestId, Transport};
 use super::frame_buf::{FrameBuf, FrameDeque};
 use futures::{Future, Poll, Async};
 use futures::stream::{Stream};

--- a/src/multiplex/server.rs
+++ b/src/multiplex/server.rs
@@ -1,4 +1,5 @@
-use super::{multiplex, RequestId, Error, Message, ServerService, Transport};
+use {Error};
+use super::{multiplex, RequestId, Message, ServerService, Transport};
 use futures::{Future, Poll, Async};
 use std::io;
 

--- a/src/multiplex/server.rs
+++ b/src/multiplex/server.rs
@@ -1,5 +1,5 @@
-use {Error};
-use super::{multiplex, RequestId, Message, ServerService, Transport};
+use {Error, Message};
+use super::{multiplex, RequestId, ServerService, Transport};
 use futures::{Future, Poll, Async};
 use std::io;
 

--- a/src/pipeline/client.rs
+++ b/src/pipeline/client.rs
@@ -8,8 +8,8 @@ use tokio_core::reactor::Handle;
 use tokio_core::channel::{channel, Sender, Receiver};
 
 use tokio_service::Service;
-use {Error};
-use super::{pipeline, Message, Transport, NewTransport};
+use {Error, Message};
+use super::{pipeline, Transport, NewTransport};
 
 /// Client `Service` for the pipeline protocol.
 pub struct Client<Req, Resp, ReqBody, E>

--- a/src/pipeline/client.rs
+++ b/src/pipeline/client.rs
@@ -8,7 +8,8 @@ use tokio_core::reactor::Handle;
 use tokio_core::channel::{channel, Sender, Receiver};
 
 use tokio_service::Service;
-use super::{pipeline, Error, Message, Transport, NewTransport};
+use {Error};
+use super::{pipeline, Message, Transport, NewTransport};
 
 /// Client `Service` for the pipeline protocol.
 pub struct Client<Req, Resp, ReqBody, E>

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -28,9 +28,9 @@ mod client;
 mod server;
 mod pipeline;
 
-pub use self::client::{connect, Client, Connecting};
 pub use self::server::Server;
 
+pub use self::client::{connect, Client, Connecting};
 use tokio_core::io::FramedIo;
 use tokio_service::Service;
 use futures::{Async, Future, IntoFuture, Poll};
@@ -61,15 +61,6 @@ pub enum Message<T, B> {
     WithoutBody(T),
     /// Has associated streaming body
     WithBody(T, B),
-}
-
-/// Error returned as an Error frame or an `io::Error` that occurerred during
-/// normal processing of the Transport
-pub enum Error<E> {
-    /// Transport frame level error
-    Transport(E),
-    /// I/O level error
-    Io(io::Error),
 }
 
 /// A specialization of `Service` supporting the requirements of server
@@ -400,14 +391,5 @@ impl<F, R, T> NewTransport for Take<F>
 
     fn new_transport(&self) -> Self::Future {
         self.take()().into_future()
-    }
-}
-
-impl From<Error<io::Error>> for io::Error {
-    fn from(err: Error<io::Error>) -> Self {
-        match err {
-            Error::Transport(e) |
-            Error::Io(e) => e,
-        }
     }
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -29,14 +29,15 @@ mod server;
 mod pipeline;
 
 pub use self::server::Server;
-
 pub use self::client::{connect, Client, Connecting};
+
+use {Message};
 use tokio_core::io::FramedIo;
 use tokio_service::Service;
 use futures::{Async, Future, IntoFuture, Poll};
 use futures::stream::{Stream, Sender};
 use take::Take;
-use std::{cmp, fmt, io, ops};
+use std::{fmt, io};
 
 /// A pipelined protocol frame
 pub enum Frame<T, B, E> {
@@ -53,14 +54,6 @@ pub enum Frame<T, B, E> {
     Error(E),
     /// Final frame sent in each transport direction
     Done,
-}
-
-/// Message sent and received from a pipeline service
-pub enum Message<T, B> {
-    /// Has no associated streaming body
-    WithoutBody(T),
-    /// Has associated streaming body
-    WithBody(T, B),
 }
 
 /// A specialization of `Service` supporting the requirements of server
@@ -221,75 +214,6 @@ impl<T, B, E> fmt::Debug for Frame<T, B, E>
             Frame::Body(ref v) => write!(fmt, "Frame::Body({:?})", v),
             Frame::Error(ref v) => write!(fmt, "Frame::Error({:?})", v),
             Frame::Done => write!(fmt, "Frame::Done"),
-        }
-    }
-}
-
-/*
- *
- * ===== impl Message =====
- *
- */
-
-impl<T, B> Message<T, B> {
-    /// If the `Message` value has an associated body stream, return it. The
-    /// original `Message` value will then become a `WithoutBody` variant.
-    pub fn take_body(&mut self) -> Option<B> {
-        use std::ptr;
-
-        // unfortunate that this is unsafe, but I think it is preferable to add
-        // a little bit of unsafe code instead of adding a useless variant to
-        // Message.
-        unsafe {
-            match ptr::read(self as *const Message<T, B>) {
-                m @ Message::WithoutBody(..) => {
-                    ptr::write(self as *mut Message<T, B>, m);
-                    None
-                }
-                Message::WithBody(m, b) => {
-                    ptr::write(self as *mut Message<T, B>, Message::WithoutBody(m));
-                    Some(b)
-                }
-            }
-        }
-    }
-}
-
-impl<T, B> cmp::PartialEq<T> for Message<T, B>
-    where T: cmp::PartialEq
-{
-    fn eq(&self, other: &T) -> bool {
-        (**self).eq(other)
-    }
-}
-
-impl<T, B> ops::Deref for Message<T, B> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        match *self {
-            Message::WithoutBody(ref v) => v,
-            Message::WithBody(ref v, _) => v,
-        }
-    }
-}
-
-impl<T, B> ops::DerefMut for Message<T, B> {
-    fn deref_mut(&mut self) -> &mut T {
-        match *self {
-            Message::WithoutBody(ref mut v) => v,
-            Message::WithBody(ref mut v, _) => v,
-        }
-    }
-}
-
-impl<T, B> fmt::Debug for Message<T, B>
-    where T: fmt::Debug
-{
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Message::WithoutBody(ref v) => write!(fmt, "Message::WithoutBody({:?})", v),
-            Message::WithBody(ref v, _) => write!(fmt, "Message::WithBody({:?}, ...)", v),
         }
     }
 }

--- a/src/pipeline/pipeline.rs
+++ b/src/pipeline/pipeline.rs
@@ -1,4 +1,5 @@
-use super::{Error, Frame, Message, Transport};
+use {Error};
+use super::{Frame, Message, Transport};
 use futures::stream::{Stream, Sender, FutureSender};
 use futures::{Future, Poll, Async};
 use std::io;

--- a/src/pipeline/pipeline.rs
+++ b/src/pipeline/pipeline.rs
@@ -1,5 +1,5 @@
-use {Error};
-use super::{Frame, Message, Transport};
+use {Error, Message};
+use super::{Frame, Transport};
 use futures::stream::{Stream, Sender, FutureSender};
 use futures::{Future, Poll, Async};
 use std::io;

--- a/src/pipeline/pipeline.rs
+++ b/src/pipeline/pipeline.rs
@@ -277,6 +277,8 @@ impl<S, T, E> Pipeline<S, T>
                 match body.poll() {
                     Ok(Async::Ready(Some(chunk))) => {
                         let r = try!(self.transport.write(Frame::Body(Some(chunk))));
+
+                        // TODO: This doesn't seem correct anymore
                         if !r.is_ready() {
                             return Ok(false);
                         }

--- a/src/pipeline/server.rs
+++ b/src/pipeline/server.rs
@@ -1,5 +1,5 @@
-use {Error};
-use super::{pipeline, Message, ServerService, Transport};
+use {Error, Message};
+use super::{pipeline, ServerService, Transport};
 use std::collections::VecDeque;
 use std::io;
 use futures::{Future, Poll, Async};

--- a/src/pipeline/server.rs
+++ b/src/pipeline/server.rs
@@ -1,4 +1,5 @@
-use super::{pipeline, Error, Message, ServerService, Transport};
+use {Error};
+use super::{pipeline, Message, ServerService, Transport};
 use std::collections::VecDeque;
 use std::io;
 use futures::{Future, Poll, Async};

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,0 +1,70 @@
+//! Utility for managing a `futures::stream::Sender` and backpressure.
+//!
+//! Remove this if alexcrichton/futures-rs#issues/164 lands.
+use futures::{Future, Async, Poll};
+use futures::stream;
+
+pub struct Sender<T, E> {
+    inner: Option<State<T, E>>,
+}
+
+enum State<T, E> {
+    Ready(stream::Sender<T, E>),
+    Busy(stream::FutureSender<T, E>),
+}
+
+impl<T, E> Sender<T, E> {
+    pub fn send(&mut self, t: Result<T, E>) {
+        trace!("Sender::send");
+
+        match self.inner.take() {
+            Some(State::Ready(sender)) => {
+                let busy = sender.send(t);
+                self.inner = Some(State::Busy(busy));
+            }
+            _ => panic!("invalid internal state"),
+        }
+    }
+
+    pub fn poll_ready(&mut self) -> Poll<(), ()> {
+        trace!("Sender::poll_ready");
+
+        match self.inner {
+            Some(State::Ready(..)) => {
+                trace!("   --> sender already ready");
+                Ok(Async::Ready(()))
+            }
+            _ => {
+                match self.inner.take() {
+                    Some(State::Busy(mut sender)) => {
+                        trace!("   --> polling future sender");
+
+                        match sender.poll() {
+                            Ok(Async::Ready(sender)) => {
+                                trace!("   --> ready");
+                                // The sender is ready
+                                self.inner = Some(State::Ready(sender));
+                                Ok(Async::Ready(()))
+                            }
+                            Ok(Async::NotReady) => {
+                                self.inner = Some(State::Busy(sender));
+                                Ok(Async::NotReady)
+                            }
+                            Err(_) =>{
+                                Err(())
+                            }
+                        }
+                    }
+                    None => Err(()),
+                    _ => panic!("invalid state"),
+                }
+            }
+        }
+    }
+}
+
+impl<T, E> From<stream::Sender<T, E>> for Sender<T, E> {
+    fn from(src: stream::Sender<T, E>) -> Sender<T, E> {
+        Sender { inner: Some(State::Ready(src)) }
+    }
+}

--- a/tests/test_multiplex_server.rs
+++ b/tests/test_multiplex_server.rs
@@ -13,7 +13,8 @@ mod support;
 use futures::stream::{Receiver};
 use futures::{Future, finished, oneshot};
 use support::mock;
-use tokio_proto::multiplex::{self, RequestId, Frame, Message};
+use tokio_proto::Message;
+use tokio_proto::multiplex::{self, RequestId, Frame};
 use tokio_core::reactor::Core;
 use rand::Rng;
 use std::io;
@@ -29,7 +30,7 @@ type Body = Receiver<u32, io::Error>;
 
 // Frame written to the transport
 type InFrame = Frame<Msg, u32, io::Error>;
-type OutFrame = Frame<multiplex::Message<Msg, Body>, u32, io::Error>;
+type OutFrame = Frame<Message<Msg, Body>, u32, io::Error>;
 
 #[test]
 fn test_immediate_done() {
@@ -334,7 +335,7 @@ fn msg(request_id: RequestId, msg: Msg) -> OutFrame {
 /// Setup a reactor running a multiplex::Server with the given service and a
 /// mock transport. Yields the mock transport handle to the function.
 fn run<S, F>(service: S, f: F)
-    where S: multiplex::ServerService<Request = multiplex::Message<Msg, Body>,
+    where S: multiplex::ServerService<Request = Message<Msg, Body>,
                                      Response = Msg,
                                          Body = u32,
                                    BodyStream = Body,

--- a/tests/test_pipeline_client.rs
+++ b/tests/test_pipeline_client.rs
@@ -14,7 +14,7 @@ use futures::stream::{self, Receiver};
 use futures::{Future, oneshot};
 use support::mock;
 use tokio_service::Service;
-use tokio_proto::pipeline;
+use tokio_proto::{pipeline, Message};
 use tokio_core::reactor::Core;
 use std::io;
 use std::thread;
@@ -38,7 +38,7 @@ fn test_ping_pong_close() {
     run(|mock, service| {
         mock.allow_write();
 
-        let pong = service.call(pipeline::Message::WithoutBody("ping"));
+        let pong = service.call(Message::WithoutBody("ping"));
         assert_eq!("ping", mock.next_write().unwrap_msg());
 
         mock.send(pipeline::Frame::Message("pong"));
@@ -57,7 +57,7 @@ fn test_response_ready_before_request_sent() {
 
         support::sleep_ms(20);
 
-        let pong = service.call(pipeline::Message::WithoutBody("ping"));
+        let pong = service.call(Message::WithoutBody("ping"));
 
         assert_eq!("pong", pong.wait().unwrap());
     });
@@ -69,7 +69,7 @@ fn test_streaming_request_body() {
         let (mut tx, rx) = stream::channel();
 
         mock.allow_write();
-        let pong = service.call(pipeline::Message::WithBody("ping", rx));
+        let pong = service.call(Message::WithBody("ping", rx));
 
         assert_eq!("ping", mock.next_write().unwrap_msg());
 

--- a/tests/test_pipeline_server.rs
+++ b/tests/test_pipeline_server.rs
@@ -13,7 +13,8 @@ mod support;
 use futures::stream::{self, Stream, Receiver};
 use futures::{Future, failed, finished, oneshot};
 use support::mock;
-use tokio_proto::pipeline::{self, Frame, Message};
+use tokio_proto::Message;
+use tokio_proto::pipeline::{self, Frame};
 use tokio_core::reactor::Core;
 use std::io;
 use std::sync::{mpsc, Arc, Mutex};
@@ -27,7 +28,7 @@ type Body = Receiver<u32, io::Error>;
 
 // Frame written to the transport
 type InFrame = Frame<Msg, u32, io::Error>;
-type OutFrame = Frame<pipeline::Message<Msg, Body>, u32, io::Error>;
+type OutFrame = Frame<Message<Msg, Body>, u32, io::Error>;
 
 #[test]
 fn test_immediate_done() {
@@ -433,7 +434,7 @@ fn msg_with_body(msg: Msg) -> OutFrame {
 /// Setup a reactor running a pipeline::Server with the given service and a
 /// mock transport. Yields the mock transport handle to the function.
 fn run<S, F>(service: S, f: F)
-    where S: pipeline::ServerService<Request = pipeline::Message<Msg, Body>,
+    where S: pipeline::ServerService<Request = Message<Msg, Body>,
                                     Response = Msg,
                                         Body = u32,
                                   BodyStream = Body,


### PR DESCRIPTION
In progress tokio-proto work. This will stay on a branch until a coordinated push can be made with all downstream crates.

Currently:

* Move types common to both pipeline / multiplex to the top level of the crate
* Start working on multiplex streaming bodies.