### PR TITLE
Change how outbound body streams are handled

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -31,3 +31,9 @@ impl<T, E> Stream for Body<T, E> {
         }
     }
 }
+
+impl<T, E> From<Receiver<T, E>> for Body<T, E> {
+    fn from(src: Receiver<T, E>) -> Body<T, E> {
+        Body { inner: Some(src) }
+    }
+}

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,0 +1,33 @@
+use futures::{Async, Poll};
+use futures::stream::{self, Stream, Receiver, Sender};
+
+/// Body stream
+pub struct Body<T, E> {
+    inner: Option<Receiver<T, E>>,
+}
+
+impl<T, E> Body<T, E> {
+    /// Return an empty body stream
+    pub fn empty() -> Body<T, E> {
+        Body { inner: None }
+    }
+
+    /// Return a body stream with an associated sender half
+    pub fn pair() -> (Sender<T, E>, Body<T, E>) {
+        let (tx, rx) = stream::channel();
+        let rx = Body { inner: Some(rx) };
+        (tx, rx)
+    }
+}
+
+impl<T, E> Stream for Body<T, E> {
+    type Item = T;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<Option<T>, E> {
+        match self.inner {
+            Some(ref mut s) => s.poll(),
+            None => Ok(Async::Ready(None)),
+        }
+    }
+}

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,5 +1,6 @@
 use futures::{Async, Poll};
 use futures::stream::{self, Stream, Receiver, Sender};
+use std::fmt;
 
 /// Body stream
 pub struct Body<T, E> {
@@ -35,5 +36,11 @@ impl<T, E> Stream for Body<T, E> {
 impl<T, E> From<Receiver<T, E>> for Body<T, E> {
     fn from(src: Receiver<T, E>) -> Body<T, E> {
         Body { inner: Some(src) }
+    }
+}
+
+impl<T, E> fmt::Debug for Body<T, E> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "Body {{ [stream of values] }}")
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -95,7 +95,8 @@ impl<T, E> Future for Response<T, E> {
             Ok(Async::Ready(Ok(v))) => Ok(Async::Ready(v)),
             Ok(Async::Ready(Err(e))) => Err(e),
             Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(_) => panic!("aborted"),
+            // TODO: This can happen if the connection failed to establish
+            Err(e) => panic!("aborted: {:?}", e),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,17 +21,16 @@ pub mod multiplex;
 pub mod pipeline;
 pub mod server;
 
+mod body;
 mod error;
 mod framing;
 mod io;
 mod message;
 mod sender;
 
+pub use body::Body;
 pub use client::Client;
 pub use error::Error;
 pub use framing::{Framed, Parse, Serialize};
 pub use io::{TryRead, TryWrite};
 pub use message::Message;
-
-/// Outbound body stream type
-pub type Body<T, E> = futures::stream::Receiver<T, E>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,6 @@ pub use error::Error;
 pub use framing::{Framed, Parse, Serialize};
 pub use io::{TryRead, TryWrite};
 pub use message::Message;
+
+/// Outbound body stream type
+pub type Body<T, E> = futures::stream::Receiver<T, E>;

--- a/src/multiplex/client.rs
+++ b/src/multiplex/client.rs
@@ -127,6 +127,10 @@ impl<T, B> Drop for Dispatch<T, B>
           B: Stream<Item = T::BodyIn, Error = T::Error>,
 {
     fn drop(&mut self) {
+        if !self.in_flight.is_empty() {
+            warn!("multiplex client dropping with in-flight exchanges");
+        }
+
         // Complete any pending requests with an error
         for (_, complete) in self.in_flight.drain() {
             let err = Error::Io(broken_pipe());

--- a/src/multiplex/frame_buf.rs
+++ b/src/multiplex/frame_buf.rs
@@ -123,6 +123,11 @@ impl<T> FrameDeque<T> {
         }
     }
 
+    pub fn clear(&mut self) {
+        while let Some(_) = self.pop() {
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.len.get()
     }

--- a/src/multiplex/mod.rs
+++ b/src/multiplex/mod.rs
@@ -241,3 +241,71 @@ impl<T, M1, M2, B1, B2, E> Transport for T
         FramedIo::flush(self)
     }
 }
+
+impl<M1, M2, B1, B2, E> Transport for Box<Transport<In = M1, Out = M2, BodyIn = B1, BodyOut = B2, Error = E>>
+    where E: From<Error<E>> + 'static,
+          M1: 'static,
+          M2: 'static,
+          B1: 'static,
+          B2: 'static,
+{
+    type In = M1;
+    type BodyIn = B1;
+    type Out = M2;
+    type BodyOut = B2;
+    type Error = E;
+
+    fn poll_read(&mut self) -> Async<()> {
+        (**self).poll_read()
+    }
+
+    fn read(&mut self) -> Poll<Frame<M2, B2, E>, io::Error> {
+        (**self).read()
+    }
+
+    fn poll_write(&mut self) -> Async<()> {
+        (**self).poll_write()
+    }
+
+    fn write(&mut self, req: Frame<M1, B1, E>) -> Poll<(), io::Error> {
+        (**self).write(req)
+    }
+
+    fn flush(&mut self) -> Poll<(), io::Error> {
+        (**self).flush()
+    }
+}
+
+impl<M1, M2, B1, B2, E> Transport for Box<Transport<In = M1, Out = M2, BodyIn = B1, BodyOut = B2, Error = E> + Send>
+    where E: From<Error<E>> + 'static,
+          M1: 'static,
+          M2: 'static,
+          B1: 'static,
+          B2: 'static,
+{
+    type In = M1;
+    type BodyIn = B1;
+    type Out = M2;
+    type BodyOut = B2;
+    type Error = E;
+
+    fn poll_read(&mut self) -> Async<()> {
+        (**self).poll_read()
+    }
+
+    fn read(&mut self) -> Poll<Frame<M2, B2, E>, io::Error> {
+        (**self).read()
+    }
+
+    fn poll_write(&mut self) -> Async<()> {
+        (**self).poll_write()
+    }
+
+    fn write(&mut self, req: Frame<M1, B1, E>) -> Poll<(), io::Error> {
+        (**self).write(req)
+    }
+
+    fn flush(&mut self) -> Poll<(), io::Error> {
+        (**self).flush()
+    }
+}

--- a/src/multiplex/mod.rs
+++ b/src/multiplex/mod.rs
@@ -42,12 +42,13 @@ pub use self::server::Server;
 use {Error};
 use tokio_core::io::FramedIo;
 use futures::{Async, Poll};
-use std::{fmt, io};
+use std::{io};
 
 /// Identifies a request / response thread
 pub type RequestId = u64;
 
 /// A multiplexed protocol frame
+#[derive(Debug, Clone)]
 pub enum Frame<T, B, E> {
     /// Either a request or a response.
     Message {
@@ -166,37 +167,6 @@ impl<T, B, E> Frame<T, B, E> {
         match *self {
             Frame::Done => true,
             _ => false,
-        }
-    }
-}
-
-impl<T, B, E> fmt::Debug for Frame<T, B, E>
-    where T: fmt::Debug,
-          E: fmt::Debug,
-          B: fmt::Debug,
-{
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Frame::Message { id, ref message, body } => {
-                fmt.debug_struct("Frame::Message")
-                    .field("id", &id)
-                    .field("message", message)
-                    .field("body", &body)
-                    .finish()
-            }
-            Frame::Body { id, ref chunk } => {
-                fmt.debug_struct("Frame::Body")
-                    .field("id", &id)
-                    .field("chunk", chunk)
-                    .finish()
-            }
-            Frame::Error { ref id, ref error } => {
-                fmt.debug_struct("Frame::Error")
-                    .field("id", &id)
-                    .field("error", error)
-                    .finish()
-            },
-            Frame::Done => write!(fmt, "Frame::Done"),
         }
     }
 }

--- a/src/multiplex/mod.rs
+++ b/src/multiplex/mod.rs
@@ -58,6 +58,9 @@ pub enum Frame<T, B, E> {
         message: T,
         /// Set to true when body frames will follow with the same request ID.
         body: bool,
+        /// Set to `true` when this message does not have a pair in the other
+        /// direction
+        solo: bool,
     },
     /// Body frame.
     Body {

--- a/src/multiplex/multiplex.rs
+++ b/src/multiplex/multiplex.rs
@@ -3,7 +3,7 @@ use super::{Frame, RequestId, Transport};
 use super::frame_buf::{FrameBuf, FrameDeque};
 use sender::Sender;
 use futures::{Future, Poll, Async};
-use futures::stream::{self, Stream};
+use futures::stream::{Stream};
 use std::io;
 use std::collections::{HashMap, VecDeque};
 use std::collections::hash_map::Entry;
@@ -264,7 +264,7 @@ impl<T> Multiplex<T> where T: Dispatch {
         match frame {
             Frame::Message { id, message, body } => {
                 if body {
-                    let (tx, rx) = stream::channel();
+                    let (tx, rx) = Body::pair();
                     let tx = Sender::new(tx);
                     let message = Message::WithBody(message, rx);
 
@@ -839,7 +839,10 @@ impl<T: Dispatch> Exchange<T> {
     fn try_poll_in_body(&mut self) -> Poll<Option<T::BodyIn>, T::Error> {
         match self.in_body {
             Some(ref mut b) => b.poll(),
-            _ => Ok(Async::NotReady),
+            None => {
+                trace!(" !!! no in body??");
+                Ok(Async::NotReady)
+            }
         }
     }
 

--- a/src/multiplex/multiplex.rs
+++ b/src/multiplex/multiplex.rs
@@ -734,6 +734,14 @@ impl<T> Future for Multiplex<T>
     }
 }
 
+impl<T: Dispatch> Drop for Multiplex<T> {
+    fn drop(&mut self) {
+        if !self.exchanges.is_empty() {
+            warn!("multiplexer dropping with in-flight exchanges");
+        }
+    }
+}
+
 impl<T: Dispatch> Exchange<T> {
     fn new(request: Request<T>, deque: FrameDeque<Option<Result<T::BodyOut, T::Error>>>) -> Exchange<T> {
         Exchange {

--- a/src/multiplex/server.rs
+++ b/src/multiplex/server.rs
@@ -148,10 +148,14 @@ impl<S, T, B> Future for Server<S, T, B>
           B: Stream<Item = T::BodyIn, Error = T::Error>,
 {
     type Item = ();
-    type Error = io::Error;
+    type Error = ();
 
-    fn poll(&mut self) -> Poll<(), io::Error> {
+    fn poll(&mut self) -> Poll<(), ()> {
         self.inner.poll()
+            .map_err(|e| {
+                debug!("multiplex server connection hit error; {:?}", e);
+                ()
+            })
     }
 }
 

--- a/src/pipeline/client.rs
+++ b/src/pipeline/client.rs
@@ -38,7 +38,7 @@ pub fn connect<T, F, B>(new_transport: F, handle: &Handle)
         })
         .map_err(|e| {
             // TODO: where to punt this error to?
-            error!("multiplex error: {}", e);
+            error!("pipeline error: {}", e);
         });
 
     // Spawn the task

--- a/src/pipeline/client.rs
+++ b/src/pipeline/client.rs
@@ -1,45 +1,44 @@
-use {Error, Message};
-use super::{Transport, NewTransport};
-use super::pipeline::{self, Pipeline};
+use {Error, Body, Message};
+use super::{Transport};
+use super::pipeline::{self, Pipeline, PipelineMessage};
 use client::{self, Client, Receiver};
 use futures::stream::Stream;
-use futures::{Future, Complete, Async};
+use futures::{Future, IntoFuture, Complete, Poll, Async};
 use tokio_core::reactor::Handle;
 use std::collections::VecDeque;
 use std::io;
 
-struct Dispatch<T, B, E>
-    where T: Transport<Error = E>,
-          B: Stream<Item = T::BodyIn, Error = E>,
-          E: From<Error<E>>,
+struct Dispatch<T, B>
+    where T: Transport,
+          B: Stream<Item = T::BodyIn, Error = T::Error>,
 {
-    requests: Receiver<T::In, T::Out, B, E>,
-    in_flight: VecDeque<Complete<Result<T::Out, E>>>,
+    transport: T,
+    requests: Receiver<T::In, T::Out, B, Body<T::BodyOut, T::Error>, T::Error>,
+    in_flight: VecDeque<Complete<Result<Message<T::Out, Body<T::BodyOut, T::Error>>, T::Error>>>,
 }
 
 /// Connect to the given `addr` and handle using the given Transport and protocol pipelining.
-pub fn connect<T, B, E>(new_transport: T, handle: &Handle) -> Client<T::In, T::Out, B, E>
-    where T: NewTransport<Error = E>,
-          T::In: Send + 'static,
-          T::Out: Send + 'static,
-          T::Item: Send + 'static,
-          T::Future: Send + 'static,
-          B: Stream<Item = T::BodyIn, Error = E> + Send + 'static,
-          E: From<Error<E>> + Send + 'static,
+pub fn connect<T, F, B>(new_transport: F, handle: &Handle)
+    -> Client<T::In, T::Out, B, Body<T::BodyOut, T::Error>, T::Error>
+    where F: IntoFuture<Item = T, Error = io::Error> + 'static,
+          T: Transport,
+          B: Stream<Item = T::BodyIn, Error = T::Error> + 'static,
 {
     let (client, rx) = client::pair();
 
-    // Create the client dispatch
-    let dispatch: Dispatch<T::Item, B, E> = Dispatch {
-        requests: rx,
-        in_flight: VecDeque::with_capacity(32),
-    };
+    let task = new_transport.into_future()
+        .and_then(move |transport| {
+            let dispatch: Dispatch<T, B> = Dispatch {
+                transport: transport,
+                requests: rx,
+                in_flight: VecDeque::with_capacity(32),
+            };
 
-    let task = new_transport.new_transport()
-        .and_then(|transport| Pipeline::new(dispatch, transport))
+            Pipeline::new(dispatch)
+        })
         .map_err(|e| {
             // TODO: where to punt this error to?
-            error!("pipeline error: {}", e);
+            error!("multiplex error: {}", e);
         });
 
     // Spawn the task
@@ -49,20 +48,25 @@ pub fn connect<T, B, E>(new_transport: T, handle: &Handle) -> Client<T::In, T::O
     client
 }
 
-impl<T, B, E> pipeline::Dispatch for Dispatch<T, B, E>
-    where T: Transport<Error = E>,
-          B: Stream<Item = T::BodyIn, Error = E>,
-          E: From<Error<E>>,
+impl<T, B> pipeline::Dispatch for Dispatch<T, B>
+    where T: Transport,
+          B: Stream<Item = T::BodyIn, Error = T::Error> + 'static,
 {
-    type InMsg = T::In;
-    type InBody = T::BodyIn;
-    type InBodyStream = B;
-    type OutMsg = T::Out;
-    type Error = E;
+    type In = T::In;
+    type BodyIn = T::BodyIn;
+    type Out = T::Out;
+    type BodyOut = T::BodyOut;
+    type Error = T::Error;
+    type Stream = B;
+    type Transport = T;
 
-    fn dispatch(&mut self, response: Self::OutMsg) -> io::Result<()> {
+    fn transport(&mut self) -> &mut Self::Transport {
+        &mut self.transport
+    }
+
+    fn dispatch(&mut self, response: PipelineMessage<Self::Out, Body<Self::BodyOut, Self::Error>, Self::Error>) -> io::Result<()> {
         if let Some(complete) = self.in_flight.pop_front() {
-            complete.complete(Ok(response));
+            complete.complete(response);
         } else {
             return Err(io::Error::new(io::ErrorKind::Other, "request / response mismatch"));
         }
@@ -70,7 +74,7 @@ impl<T, B, E> pipeline::Dispatch for Dispatch<T, B, E>
         Ok(())
     }
 
-    fn poll(&mut self) -> Option<Result<Message<Self::InMsg, Self::InBodyStream>, Self::Error>> {
+    fn poll(&mut self) -> Poll<Option<PipelineMessage<Self::In, Self::Stream, Self::Error>>, io::Error> {
         trace!("Dispatch::poll");
         // Try to get a new request frame
         match self.requests.poll() {
@@ -80,12 +84,12 @@ impl<T, B, E> pipeline::Dispatch for Dispatch<T, B, E>
                 // Track complete handle
                 self.in_flight.push_back(complete);
 
-                Some(Ok(request))
+                Ok(Async::Ready(Some(Ok(request))))
 
             }
             Ok(Async::Ready(None)) => {
                 trace!("   --> client dropped");
-                None
+                Ok(Async::Ready(None))
             }
             Err(e) => {
                 trace!("   --> error");
@@ -96,7 +100,7 @@ impl<T, B, E> pipeline::Dispatch for Dispatch<T, B, E>
             }
             Ok(Async::NotReady) => {
                 trace!("   --> not ready");
-                None
+                Ok(Async::NotReady)
             }
         }
     }
@@ -106,10 +110,9 @@ impl<T, B, E> pipeline::Dispatch for Dispatch<T, B, E>
     }
 }
 
-impl<T, B, E> Drop for Dispatch<T, B, E>
-    where T: Transport<Error = E>,
-          B: Stream<Item = T::BodyIn, Error = E>,
-          E: From<Error<E>>,
+impl<T, B> Drop for Dispatch<T, B>
+    where T: Transport,
+          B: Stream<Item = T::BodyIn, Error = T::Error>,
 {
     fn drop(&mut self) {
         // Complete any pending requests with an error

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -43,7 +43,7 @@ pub enum Frame<T, B, E> {
     Message {
         /// The message value
         message: T,
-        /// Set to true when body frames will follow with the same request ID.
+        /// Set to true when body frames will follow
         body: bool,
     },
     /// Body frame. None indicates that the body is done streaming.

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -35,9 +35,10 @@ pub use self::client::connect;
 use {Error};
 use tokio_core::io::FramedIo;
 use futures::{Async, Poll};
-use std::{fmt, io};
+use std::{io};
 
 /// A pipelined protocol frame
+#[derive(Debug, Clone)]
 pub enum Frame<T, B, E> {
     /// Either a request or a response
     Message {
@@ -140,34 +141,6 @@ impl<T, B, E> Frame<T, B, E> {
         match *self {
             Frame::Done => true,
             _ => false,
-        }
-    }
-}
-
-impl<T, B, E> fmt::Debug for Frame<T, B, E>
-    where T: fmt::Debug,
-          E: fmt::Debug,
-          B: fmt::Debug,
-{
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Frame::Message { ref message, body } => {
-                fmt.debug_struct("Frame::Message")
-                    .field("message", message)
-                    .field("body", &body)
-                    .finish()
-            }
-            Frame::Body { ref chunk } => {
-                fmt.debug_struct("Frame::Body")
-                    .field("chunk", chunk)
-                    .finish()
-            }
-            Frame::Error { ref error } => {
-                fmt.debug_struct("Frame::Error")
-                    .field("error", error)
-                    .finish()
-            },
-            Frame::Done => write!(fmt, "Frame::Done"),
         }
     }
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -212,3 +212,71 @@ impl<T, M1, M2, B1, B2, E> Transport for T
         FramedIo::flush(self)
     }
 }
+
+impl<M1, M2, B1, B2, E> Transport for Box<Transport<In = M1, Out = M2, BodyIn = B1, BodyOut = B2, Error = E>>
+    where E: From<Error<E>> + 'static,
+          M1: 'static,
+          M2: 'static,
+          B1: 'static,
+          B2: 'static,
+{
+    type In = M1;
+    type BodyIn = B1;
+    type Out = M2;
+    type BodyOut = B2;
+    type Error = E;
+
+    fn poll_read(&mut self) -> Async<()> {
+        (**self).poll_read()
+    }
+
+    fn read(&mut self) -> Poll<Frame<M2, B2, E>, io::Error> {
+        (**self).read()
+    }
+
+    fn poll_write(&mut self) -> Async<()> {
+        (**self).poll_write()
+    }
+
+    fn write(&mut self, req: Frame<M1, B1, E>) -> Poll<(), io::Error> {
+        (**self).write(req)
+    }
+
+    fn flush(&mut self) -> Poll<(), io::Error> {
+        (**self).flush()
+    }
+}
+
+impl<M1, M2, B1, B2, E> Transport for Box<Transport<In = M1, Out = M2, BodyIn = B1, BodyOut = B2, Error = E> + Send>
+    where E: From<Error<E>> + 'static,
+          M1: 'static,
+          M2: 'static,
+          B1: 'static,
+          B2: 'static,
+{
+    type In = M1;
+    type BodyIn = B1;
+    type Out = M2;
+    type BodyOut = B2;
+    type Error = E;
+
+    fn poll_read(&mut self) -> Async<()> {
+        (**self).poll_read()
+    }
+
+    fn read(&mut self) -> Poll<Frame<M2, B2, E>, io::Error> {
+        (**self).read()
+    }
+
+    fn poll_write(&mut self) -> Async<()> {
+        (**self).poll_write()
+    }
+
+    fn write(&mut self, req: Frame<M1, B1, E>) -> Poll<(), io::Error> {
+        (**self).write(req)
+    }
+
+    fn flush(&mut self) -> Poll<(), io::Error> {
+        (**self).flush()
+    }
+}

--- a/src/pipeline/pipeline.rs
+++ b/src/pipeline/pipeline.rs
@@ -1,6 +1,6 @@
 use {Error, Message, Body};
 use super::{Frame, Transport};
-use futures::stream::{self, Stream, Sender, FutureSender};
+use futures::stream::{Stream, Sender, FutureSender};
 use futures::{Future, Poll, Async};
 use std::io;
 
@@ -147,7 +147,7 @@ impl<T> Pipeline<T> where T: Dispatch {
                 if body {
                     trace!("read out message with body");
 
-                    let (tx, rx) = stream::channel();
+                    let (tx, rx) = Body::pair();
                     let message = Message::WithBody(message, rx);
 
                     // Track the out body sender. If `self.out_body`

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 pub mod mock;
+pub mod multiplex;
 
 use std::time::Duration;
 

--- a/tests/support/multiplex.rs
+++ b/tests/support/multiplex.rs
@@ -16,6 +16,7 @@ use self::tokio_service::{Service, simple_service};
 use support::mock;
 
 use futures::{Future, oneshot};
+use futures::stream::Stream;
 use std::{io, thread};
 use std::sync::{mpsc};
 
@@ -27,6 +28,9 @@ pub type Chunk = u32;
 
 /// Streaming body
 pub type Body = ::tokio_proto::Body<Chunk, io::Error>;
+
+/// Streaming response type
+pub type BodyBox = Box<Stream<Item = Chunk, Error = io::Error> + Send + 'static>;
 
 /// Protocol frame
 pub type Frame = ::tokio_proto::multiplex::Frame<Head, Chunk, io::Error>;
@@ -74,20 +78,47 @@ pub fn done() -> Frame {
     proto::Frame::Done
 }
 
+pub trait NewTransport: Send + 'static {
+    type Transport: proto::Transport<In = Head,
+                                    Out = Head,
+                                 BodyIn = Chunk,
+                                BodyOut = Chunk,
+                                  Error = io::Error> + Send;
+
+    fn new_transport(self, transport: mock::Transport<Frame, Frame>) -> Self::Transport;
+}
+
 /// Setup a reactor running a multiplex::Server with the given service and a
 /// mock transport. Yields the mock transport handle to the function.
 pub fn run<S, F>(service: S, f: F)
     where S: Service<Request = Message<Head, Body>,
-                    Response = Message<Head, Body>,
+                    Response = Message<Head, BodyBox>,
                        Error = io::Error> + Sync + Send + 'static,
           S::Future: Send + 'static,
           F: FnOnce(mock::TransportHandle<Frame, Frame>)
 {
     let service = simple_service(move |request| {
-        Box::new(service.call(request)) as Box<Future<Item = Message<Head, Body>, Error = io::Error> + Send + 'static>
+        Box::new(service.call(request)) as Box<Future<Item = Message<Head, BodyBox>, Error = io::Error> + Send + 'static>
     });
 
-    _run(Box::new(service), f);
+    _run(Box::new(service), |t| t, f);
+}
+
+/// Setup a reactor running a multiplex::Server with the given service and a
+/// mock transport. Yields the mock transport handle to the function.
+pub fn run_with_transport<S, F, T>(service: S, new_transport: T, f: F)
+    where S: Service<Request = Message<Head, Body>,
+                    Response = Message<Head, BodyBox>,
+                       Error = io::Error> + Sync + Send + 'static,
+          S::Future: Send + 'static,
+          T: NewTransport,
+          F: FnOnce(mock::TransportHandle<Frame, Frame>)
+{
+    let service = simple_service(move |request| {
+        Box::new(service.call(request)) as Box<Future<Item = Message<Head, BodyBox>, Error = io::Error> + Send + 'static>
+    });
+
+    _run(Box::new(service), new_transport, f);
 }
 
 /// Setup a reactor running a multiplex::Client and a mock transport. Yields the
@@ -118,12 +149,22 @@ pub fn client<F>(f: F) where F: FnOnce(TransportHandle, Client) {
 }
 
 type ServerService = Box<Service<Request = Message<Head, Body>,
-                                Response = Message<Head, Body>,
+                                Response = Message<Head, BodyBox>,
                                    Error = io::Error,
-                                  Future = Box<Future<Item = Message<Head, Body>, Error = io::Error> + Send + 'static>> + Send + 'static>;
+                                  Future = Box<Future<Item = Message<Head, BodyBox>, Error = io::Error> + Send + 'static>> + Send + 'static>;
 
-fn _run<F>(service: ServerService, f: F)
-    where F: FnOnce(mock::TransportHandle<Frame, Frame>)
+type BoxTransport = Box<proto::Transport<In = Head,
+                                         Out = Head,
+                                         BodyIn = Chunk,
+                                         BodyOut = Chunk,
+                                         Error = io::Error> + Send>;
+
+// Convert to trait objects in a hope to make compiling tests faster
+fn _run<F, T>(service: ServerService,
+              new_transport: T,
+              f: F)
+    where F: FnOnce(TransportHandle),
+          T: NewTransport,
 {
     let _ = ::env_logger::init();
 
@@ -132,13 +173,17 @@ fn _run<F>(service: ServerService, f: F)
     let t = thread::spawn(move || {
         let mut lp = Core::new().unwrap();
         let handle = lp.handle();
-        let (mock, new_transport) = mock::transport::<Frame, Frame>(handle.clone());
 
-        let transport = new_transport.new_transport().unwrap();
+        let (mock, new_mock) = mock::transport::<Frame, Frame>(handle.clone());
+        let transport = new_mock.new_transport().unwrap();
+        let transport = new_transport.new_transport(transport);
+        let transport: BoxTransport = Box::new(transport);
+
         handle.spawn({
             let dispatch = proto::Server::new(service, transport);
             dispatch.map_err(|e| error!("error: {}", e))
         });
+
         tx2.send(mock).unwrap();
         lp.run(rx)
     });
@@ -148,4 +193,19 @@ fn _run<F>(service: ServerService, f: F)
 
     tx.complete(());
     t.join().unwrap().unwrap();
+}
+
+impl<F, T> NewTransport for F
+    where F: FnOnce(mock::Transport<Frame, Frame>) -> T + Send + 'static,
+          T: proto::Transport<In = Head,
+                             Out = Head,
+                          BodyIn = Chunk,
+                         BodyOut = Chunk,
+                           Error = io::Error> + Send,
+{
+    type Transport = T;
+
+    fn new_transport(self, mock: mock::Transport<Frame, Frame>) -> T {
+        self(mock)
+    }
 }

--- a/tests/support/multiplex.rs
+++ b/tests/support/multiplex.rs
@@ -1,0 +1,151 @@
+//! Infrastructure for testing the multiplexer
+//!
+//! The protocol is organized as follows:
+//!
+//! * message head: &'static str
+//! * message body chunk: u32
+//! * message body: stream of u32
+
+extern crate tokio_service;
+
+use tokio_proto::Message;
+use tokio_proto::multiplex::{self as proto, RequestId};
+use tokio_core::reactor::{Core};
+use self::tokio_service::{Service, simple_service};
+
+use support::mock;
+
+use futures::{Future, oneshot};
+use std::{io, thread};
+use std::sync::{mpsc};
+
+/// Message head
+pub type Head = &'static str;
+
+/// Streaming body chunk
+pub type Chunk = u32;
+
+/// Streaming body
+pub type Body = ::tokio_proto::Body<Chunk, io::Error>;
+
+/// Protocol frame
+pub type Frame = ::tokio_proto::multiplex::Frame<Head, Chunk, io::Error>;
+
+/// Client handle
+pub type Client = ::tokio_proto::Client<Head, Head, Body, Body, io::Error>;
+
+/// Transport handle
+pub type TransportHandle = mock::TransportHandle<Frame, Frame>;
+
+/// Return a message frame without a body
+pub fn message(id: RequestId, msg: Head) -> Frame {
+    proto::Frame::Message {
+        id: id,
+        message: msg,
+        body: false,
+    }
+}
+
+/// Return a message frame with a body
+pub fn message_with_body(id: RequestId, message: Head) -> Frame {
+    proto::Frame::Message {
+        id: id,
+        message: message,
+        body: true,
+    }
+}
+
+/// Return a body frame
+pub fn body(id: RequestId, chunk: Option<Chunk>) -> Frame {
+    proto::Frame::Body {
+        id: id,
+        chunk: chunk,
+    }
+}
+
+pub fn error(id: RequestId, error: io::Error) -> Frame {
+    proto::Frame::Error {
+        id: id,
+        error: error,
+    }
+}
+
+pub fn done() -> Frame {
+    proto::Frame::Done
+}
+
+/// Setup a reactor running a multiplex::Server with the given service and a
+/// mock transport. Yields the mock transport handle to the function.
+pub fn run<S, F>(service: S, f: F)
+    where S: Service<Request = Message<Head, Body>,
+                    Response = Message<Head, Body>,
+                       Error = io::Error> + Sync + Send + 'static,
+          S::Future: Send + 'static,
+          F: FnOnce(mock::TransportHandle<Frame, Frame>)
+{
+    let service = simple_service(move |request| {
+        Box::new(service.call(request)) as Box<Future<Item = Message<Head, Body>, Error = io::Error> + Send + 'static>
+    });
+
+    _run(Box::new(service), f);
+}
+
+/// Setup a reactor running a multiplex::Client and a mock transport. Yields the
+/// mock transport handle to the function.
+pub fn client<F>(f: F) where F: FnOnce(TransportHandle, Client) {
+    let _ = ::env_logger::init();
+
+    let (tx, rx) = oneshot();
+    let (tx2, rx2) = mpsc::channel();
+    let t = thread::spawn(move || {
+        let mut lp = Core::new().unwrap();
+        let handle = lp.handle();
+        let (mock, new_transport) = mock::transport::<Frame, Frame>(handle.clone());
+
+        let transport = new_transport.new_transport().unwrap();
+        let service = proto::connect(Ok(transport), &handle);
+
+        tx2.send((mock, service)).unwrap();
+        lp.run(rx)
+    });
+
+    let (mock, service) = rx2.recv().unwrap();
+
+    f(mock, service);
+
+    tx.complete(());
+    t.join().unwrap().unwrap();
+}
+
+type ServerService = Box<Service<Request = Message<Head, Body>,
+                                Response = Message<Head, Body>,
+                                   Error = io::Error,
+                                  Future = Box<Future<Item = Message<Head, Body>, Error = io::Error> + Send + 'static>> + Send + 'static>;
+
+fn _run<F>(service: ServerService, f: F)
+    where F: FnOnce(mock::TransportHandle<Frame, Frame>)
+{
+    let _ = ::env_logger::init();
+
+    let (tx, rx) = oneshot();
+    let (tx2, rx2) = mpsc::channel();
+    let t = thread::spawn(move || {
+        let mut lp = Core::new().unwrap();
+        let handle = lp.handle();
+        let (mock, new_transport) = mock::transport::<Frame, Frame>(handle.clone());
+
+        let transport = new_transport.new_transport().unwrap();
+        handle.spawn({
+            let dispatch = proto::Server::new(service, transport);
+            dispatch.map_err(|e| error!("error: {}", e))
+        });
+        tx2.send(mock).unwrap();
+        lp.run(rx)
+    });
+    let mock = rx2.recv().unwrap();
+
+    f(mock);
+
+    tx.complete(());
+    t.join().unwrap().unwrap();
+}

--- a/tests/support/multiplex.rs
+++ b/tests/support/multiplex.rs
@@ -136,7 +136,7 @@ pub fn client<F>(f: F) where F: FnOnce(TransportHandle, Client) {
         let (mock, new_transport) = mock::transport::<Frame, Frame>(handle.clone());
 
         let transport = new_transport.new_transport().unwrap();
-        let service = proto::connect(Ok(transport), &handle);
+        let service = proto::connect(transport, &handle);
 
         tx2.send((mock, service)).unwrap();
         lp.run(rx)
@@ -181,10 +181,7 @@ fn _run<F, T>(service: ServerService,
         let transport = new_transport.new_transport(transport);
         let transport: BoxTransport = Box::new(transport);
 
-        handle.spawn({
-            let dispatch = proto::Server::new(service, transport);
-            dispatch.map_err(|e| error!("error: {}", e))
-        });
+        handle.spawn(proto::Server::new(service, transport));
 
         tx2.send(mock).unwrap();
         lp.run(rx)

--- a/tests/support/multiplex.rs
+++ b/tests/support/multiplex.rs
@@ -47,6 +47,7 @@ pub fn message(id: RequestId, msg: Head) -> Frame {
         id: id,
         message: msg,
         body: false,
+        solo: false,
     }
 }
 
@@ -56,6 +57,7 @@ pub fn message_with_body(id: RequestId, message: Head) -> Frame {
         id: id,
         message: message,
         body: true,
+        solo: false,
     }
 }
 

--- a/tests/test_multiplex_client.rs
+++ b/tests/test_multiplex_client.rs
@@ -10,36 +10,18 @@ extern crate env_logger;
 
 mod support;
 
-use futures::{Future, oneshot};
-use futures::stream::{Stream, Receiver};
-use support::mock;
+use support::multiplex as mux;
+
+use futures::{Future};
+use futures::stream::{Stream};
 use tokio_service::Service;
 use tokio_proto::Message;
-use tokio_proto::multiplex::{self, Frame, RequestId};
-use tokio_core::reactor::Core;
+use tokio_proto::multiplex;
 use std::io;
-use std::thread;
-use std::sync::mpsc;
-
-// The message type is a static string for both the request and response
-type Msg = &'static str;
-
-// The body stream is a stream of u32 values
-type Body = Receiver<u32, io::Error>;
-
-// Frame written to the transport
-type InFrame = Frame<Msg, u32, io::Error>;
-type OutFrame = Frame<Msg, u32, io::Error>;
-
-// Transport handle
-type TransportHandle = mock::TransportHandle<InFrame, OutFrame>;
-
-// Client handle
-type Client = tokio_proto::Client<Msg, Msg, Body, Body, io::Error>;
 
 #[test]
 fn test_ping_pong_close() {
-    run(|mock, service| {
+    mux::client(|mock, service| {
         mock.allow_write();
 
         let pong = service.call(Message::WithoutBody("ping"));
@@ -47,7 +29,7 @@ fn test_ping_pong_close() {
         assert_eq!(Some(0), wr.request_id());
         assert_eq!("ping", wr.unwrap_msg());
 
-        mock.send(msg(0, "pong"));
+        mock.send(mux::message(0, "pong"));
         assert_eq!("pong", pong.wait().unwrap().into_inner());
 
         mock.send(multiplex::Frame::Done);
@@ -57,7 +39,7 @@ fn test_ping_pong_close() {
 
 #[test]
 fn test_error_on_response() {
-    run(|mock, service| {
+    mux::client(|mock, service| {
         mock.allow_write();
 
         let pong = service.call(Message::WithoutBody("ping"));
@@ -80,7 +62,7 @@ fn test_error_on_response() {
 
 #[test]
 fn drop_client_while_streaming_body() {
-    run(|mock, service| {
+    mux::client(|mock, service| {
         mock.allow_write();
 
         let pong = service.call(Message::WithoutBody("ping"));
@@ -89,7 +71,7 @@ fn drop_client_while_streaming_body() {
         assert_eq!(Some(0), wr.request_id());
         assert_eq!("ping", wr.unwrap_msg());
 
-        mock.send(msg_with_body(0, "pong"));
+        mock.send(mux::message_with_body(0, "pong"));
 
         let mut pong = pong.wait().unwrap();
         assert_eq!("pong", &pong.get_ref()[..]);
@@ -102,13 +84,13 @@ fn drop_client_while_streaming_body() {
         // Send body frames
         for i in 0..3 {
             mock.allow_write();
-            mock.send(multiplex::Frame::Body { id: 0, chunk: Some(i) });
+            mock.send(mux::body(0, Some(i)));
         }
 
         mock.allow_write();
-        mock.send(multiplex::Frame::Body { id: 0, chunk: None });
+        mock.send(mux::body(0, None));
 
-        mock.send(multiplex::Frame::Done);
+        mock.send(mux::done());
         mock.allow_write();
 
         let body: Vec<u32> = rx.wait().map(|i| i.unwrap()).collect();
@@ -116,47 +98,4 @@ fn drop_client_while_streaming_body() {
 
         mock.assert_drop();
     });
-}
-
-fn msg(request_id: RequestId, msg: Msg) -> OutFrame {
-    Frame::Message {
-        id: request_id,
-        message: msg,
-        body: false,
-    }
-}
-
-fn msg_with_body(request_id: RequestId, msg: Msg) -> OutFrame {
-    Frame::Message {
-        id: request_id,
-        message: msg,
-        body: true,
-    }
-}
-
-/// Setup a reactor running a multiplex::Client and a mock transport. Yields the
-/// mock transport handle to the function.
-fn run<F>(f: F) where F: FnOnce(TransportHandle, Client) {
-    let _ = ::env_logger::init();
-
-    let (tx, rx) = oneshot();
-    let (tx2, rx2) = mpsc::channel();
-    let t = thread::spawn(move || {
-        let mut lp = Core::new().unwrap();
-        let handle = lp.handle();
-        let (mock, new_transport) = mock::transport::<InFrame, OutFrame>(handle.clone());
-
-        let transport = new_transport.new_transport().unwrap();
-        let service = multiplex::connect(Ok(transport), &handle);
-
-        tx2.send((mock, service)).unwrap();
-        lp.run(rx)
-    });
-
-    let (mock, service) = rx2.recv().unwrap();
-
-    f(mock, service);
-
-    tx.complete(());
-    t.join().unwrap().unwrap();
 }

--- a/tests/test_multiplex_deadlock.rs
+++ b/tests/test_multiplex_deadlock.rs
@@ -1,0 +1,119 @@
+extern crate futures;
+extern crate tokio_core;
+extern crate tokio_proto;
+extern crate tokio_service;
+extern crate rand;
+
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+mod support;
+
+use support::multiplex as mux;
+
+use tokio_proto::Message;
+use tokio_proto::multiplex::{self, Frame};
+use futures::{stream, Async, Poll};
+use std::io;
+
+#[test]
+fn test_write_requires_flush() {
+
+    // Create a custom Transport middleware that requires a flush before
+    // enabling reading
+
+    struct Transport<T: multiplex::Transport> {
+        upstream: T,
+        buffer: Option<Frame<T::In, T::BodyIn, T::Error>>,
+    }
+
+    impl<T: multiplex::Transport> Transport<T> {
+        fn new(upstream: T) -> Transport<T> {
+            Transport {
+                upstream: upstream,
+                buffer: None,
+            }
+        }
+    }
+
+    impl<T> multiplex::Transport for Transport<T>
+        where T: multiplex::Transport,
+    {
+        type In = T::In;
+        type Out = T::Out;
+        type BodyIn = T::BodyIn;
+        type BodyOut = T::BodyOut;
+        type Error = T::Error;
+
+        fn poll_read(&mut self) -> Async<()> {
+            self.upstream.poll_read()
+        }
+
+        fn read(&mut self) -> Poll<Frame<Self::Out, Self::BodyOut, Self::Error>, io::Error> {
+            self.upstream.read()
+        }
+
+        fn poll_write(&mut self) -> Async<()> {
+            if self.buffer.is_none() {
+                return Async::Ready(());
+            }
+
+            Async::NotReady
+        }
+
+        fn write(&mut self, message: Frame<Self::In, Self::BodyIn, Self::Error>) -> Poll<(), io::Error> {
+            assert!(self.poll_write().is_ready());
+            self.buffer = Some(message);
+            Ok(Async::Ready(()))
+        }
+
+        fn flush(&mut self) -> Poll<(), io::Error> {
+            if self.buffer.is_some() {
+                if !self.upstream.poll_write().is_ready() {
+                    return Ok(Async::NotReady);
+                }
+
+                let msg = self.buffer.take().unwrap();
+                try!(self.upstream.write(msg));
+            }
+
+            self.upstream.flush()
+        }
+    }
+
+    // Define a simple service that just finishes immediately
+    let service = tokio_service::simple_service(|_| {
+        let body = vec![0, 1, 2].into_iter().map(Ok);
+        let body: mux::BodyBox = Box::new(stream::iter(body));
+
+        let resp = Message::WithBody("goodbye", body);
+
+        futures::finished(resp)
+    });
+
+    // Expect a ping pong
+    mux::run_with_transport(service, Transport::new, |mock| {
+        mock.allow_write();
+        mock.send(mux::message(0, "hello"));
+
+        let wr = mock.next_write();
+        assert_eq!(wr.request_id(), Some(0));
+        assert_eq!(wr.unwrap_msg(), "goodbye");
+
+        for i in 0..3 {
+            mock.allow_write();
+            let wr = mock.next_write();
+            assert_eq!(wr.request_id(), Some(0));
+            assert_eq!(wr.unwrap_body(), Some(i));
+        }
+
+        mock.allow_write();
+        let wr = mock.next_write();
+        assert_eq!(wr.request_id(), Some(0));
+        assert_eq!(wr.unwrap_body(), None);
+
+        mock.send(Frame::Done);
+        mock.allow_and_assert_drop();
+    });
+}

--- a/tests/test_pipeline_client.rs
+++ b/tests/test_pipeline_client.rs
@@ -10,7 +10,7 @@ extern crate env_logger;
 
 mod support;
 
-use futures::stream::{self, Receiver};
+use futures::stream::{self};
 use futures::{Future, oneshot};
 use support::mock;
 use tokio_service::Service;

--- a/tests/test_pipeline_client.rs
+++ b/tests/test_pipeline_client.rs
@@ -33,7 +33,7 @@ type Client = tokio_proto::Client<Msg, Msg, Body, Body, io::Error>;
 type Frame = pipeline::Frame<Msg, u32, io::Error>;
 
 // Body stream
-type Body = Receiver<u32, io::Error>;
+type Body = tokio_proto::Body<u32, io::Error>;
 
 #[test]
 fn test_ping_pong_close() {
@@ -71,7 +71,7 @@ fn test_streaming_request_body() {
         let (mut tx, rx) = stream::channel();
 
         mock.allow_write();
-        let pong = service.call(Message::WithBody("ping", rx));
+        let pong = service.call(Message::WithBody("ping", rx.into()));
 
         assert_eq!("ping", mock.next_write().unwrap_msg());
 

--- a/tests/test_pipeline_server.rs
+++ b/tests/test_pipeline_server.rs
@@ -10,7 +10,7 @@ extern crate env_logger;
 
 mod support;
 
-use futures::stream::{self, Stream, Receiver};
+use futures::stream::{self, Stream};
 use futures::{Future, failed, finished, oneshot};
 use support::mock;
 use tokio_proto::Message;
@@ -25,7 +25,7 @@ use std::thread;
 type Msg = &'static str;
 
 // The body stream is a stream of u32 values
-type Body = Receiver<u32, io::Error>;
+type Body = tokio_proto::Body<u32, io::Error>;
 
 // Frame written to the transport
 type InFrame = Frame<Msg, u32, io::Error>;
@@ -386,7 +386,7 @@ fn test_streaming_response_body() {
 
     let service = tokio_service::simple_service(move |req| {
         assert_eq!(req, "omg");
-        finished(Message::WithBody("hi2u", rx.lock().unwrap().take().unwrap()))
+        finished(Message::WithBody("hi2u", rx.lock().unwrap().take().unwrap().into()))
     });
 
     run(service, |mock| {


### PR DESCRIPTION
The transport is no longer responsible for creating a channel for the
streaming body. Instead, a flag is set in the frame and the dispatcher creates
the channel.

This means that the `Frame` enum in both pipeline and multiplex has changed.
It also means that the outbound message being dispatched must be of
`Message<T>` type vs. only `T`.

This commit also includes an internal overhaul of the multiplexer.

This PR should handle: #50, #48, #46, #49