### PR TITLE
Add an `easy` module for no streaming support

### DIFF
--- a/src/easy/mod.rs
+++ b/src/easy/mod.rs
@@ -1,0 +1,102 @@
+//! "Easy" and simplified interfaces to tokio-proto APIs.
+//!
+//! The tokio-proto `pipeline` and `multiplex` modules are relatively complex,
+//! namely because of their ability to handle streaming bodies in both requests
+//! and responses. Not all protocols, however, need this functionality. To
+//! easily get off the ground running with these kinds of protocols, this module
+//! contains simplified variants of the pipeline/multiple server/client halves
+//! to forgo streaming bodies and instead just deal with requests and responses.
+//!
+//! Clients and servers created from the easy module only require an instance of
+//! `FramedIo`, a trait defined in the `tokio-core` crate for decoding and
+//! encoding frames from a byte stream. The frames defined by `FramedIo` are
+//! then the request/response types for the clients and servers defined here.
+//!
+//! Note that this module is intended to be paired with `tokio_core::easy` as
+//! well where an instance of `EasyFramedIo` will slot nicely into all of the
+//! implementations here as well.
+//!
+//! Internally it's also important to note that all support in this module is
+//! built on top of the `pipeline` and `multiplex` modules in this crate as
+//! well, with most types just taken care of for you.
+
+use std::io;
+
+use futures::stream::Receiver;
+use futures::{Async, Future, Poll};
+use tokio_service::Service;
+
+use {Message, Body};
+use client::{Response, Client};
+
+/// A client which does not support streaming bodies.
+///
+/// This client is returned from the `easy::pipeline::connect` and
+/// `easy::multiplex::connect` functions in this crate. The client's requests
+/// and responses do not support streaming bodies. Each client implements the
+/// `Service` trait to express sending a request to the remote end of this
+/// client, and the future returned represents the response. Responses are
+/// automatically managed according to the internal protocol.
+///
+/// The `R1` type parameter here is the type of requests that this client can
+/// send, and is also the argument for the `Service::call` method trait
+/// implementation.
+///
+/// The `R2` type parameter is the type of response that will be received and
+/// is the resolved value of the future returned by `call`.
+///
+/// Note that currently this client is not generic over errors as well, but
+/// rather all errors returned are instances of `io::Error`.
+pub struct EasyClient<R1, R2> {
+    inner: Client<R1,
+                  R2,
+                  Receiver<(), io::Error>,
+                  Body<(), io::Error>,
+                  io::Error>,
+}
+
+impl<R1, R2> Service for EasyClient<R1, R2>
+    where R1: 'static,
+          R2: 'static,
+{
+    type Request = R1;
+    type Response = R2;
+    type Error = io::Error;
+    type Future = EasyResponse<R2>;
+
+    fn call(&self, request: R1) -> EasyResponse<R2> {
+        EasyResponse {
+            inner: self.inner.call(Message::WithoutBody(request)),
+        }
+    }
+
+    fn poll_ready(&self) -> Async<()> {
+        self.inner.poll_ready()
+    }
+}
+
+/// Future returned from `Client::call`.
+///
+/// This future returned from `Client::call` represents the response to a
+/// particular request. This future will either resolve to `T` or and
+/// `io::Error`.
+pub struct EasyResponse<T> {
+    inner: Response<Message<T, Body<(), io::Error>>,
+                    io::Error>,
+}
+
+impl<T> Future for EasyResponse<T> {
+    type Item = T;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<T, io::Error> {
+        match try_ready!(self.inner.poll()) {
+            Message::WithoutBody(t) => Ok(t.into()),
+            Message::WithBody(..) => panic!("easy has no body"),
+        }
+    }
+}
+
+pub mod multiplex;
+pub mod pipeline;
+

--- a/src/easy/multiplex.rs
+++ b/src/easy/multiplex.rs
@@ -1,0 +1,197 @@
+//! An "easy" multiplexing module
+//!
+//! This module is the same as the top-level `multiplex` module in this crate
+//! except that it has no support for streaming bodies. This in turn simplifies
+//! a number of generics and allows for protocols to easily get off the ground
+//! running. Additionally, requests are only allowed to be specified by one
+//! frame so request ids are automatically allocated.
+//!
+//! The API surface area of this module is the same as the top-level one, so no
+//! new functionality is introduced here. In fact all APIs here are built on top
+//! of the `multiplex` module itself, they just simplify the generics in play and
+//! such.
+
+use std::io;
+use std::marker;
+
+use futures::stream::Receiver;
+use futures::{Future, Async, Poll};
+use tokio_core::io::FramedIo;
+use tokio_core::reactor::Handle;
+use tokio_service::Service;
+
+use easy::EasyClient;
+use multiplex;
+use {Message, Body};
+
+/// The "easy" form of connecting a multiplexed client.
+///
+/// This function takes an instance of the `tokio_core::io::FrameIo` trait as
+/// the `frames` argument, a `handle` to the event loop to connect on, and then
+/// returns the connected client.
+///
+/// The client returned implements the `Service` trait. This trait
+/// implementation allows sending requests to the transport provided and returns
+/// futures to the responses. All requests are automatically multiplexed and
+/// managed internally.
+pub fn connect<F, T>(frames: F, handle: &Handle)
+    -> EasyClient<F::In, T>
+    where F: FramedIo<Out = Option<T>> + 'static,
+          F::In: 'static,
+          T: 'static,
+{
+    EasyClient {
+        inner: multiplex::connect(MyTransport::new(frames), handle),
+    }
+}
+
+struct MyTransport<F, T> {
+    inner: F,
+    next_id: u64,
+    _marker: marker::PhantomData<fn() -> T>,
+}
+
+impl<F, T> MyTransport<F, T> {
+    fn new(f: F) -> MyTransport<F, T> {
+        MyTransport {
+            inner: f,
+            next_id: 0,
+            _marker: marker::PhantomData,
+        }
+    }
+}
+
+impl<F, T> multiplex::Transport for MyTransport<F, T>
+    where F: FramedIo<Out = Option<T>> + 'static,
+          F::In: 'static,
+          T: 'static,
+{
+    type In = F::In;
+    type BodyIn = ();
+    type Out = T;
+    type BodyOut = ();
+    type Error = io::Error;
+
+    fn poll_read(&mut self) -> Async<()> {
+        self.inner.poll_read()
+    }
+
+    fn read(&mut self) -> Poll<multiplex::Frame<T, (), io::Error>, io::Error> {
+        let msg = match try_ready!(self.inner.read()) {
+            Some(msg) => msg,
+            None => return Ok(multiplex::Frame::Done.into()),
+        };
+        let id = self.next_id;
+        self.next_id += 1;
+        Ok(multiplex::Frame::Message {
+            message: msg,
+            body: false,
+            solo: false,
+            id: id,
+        }.into())
+    }
+
+    fn poll_write(&mut self) -> Async<()> {
+        self.inner.poll_write()
+    }
+
+    fn write(&mut self, req: multiplex::Frame<F::In, (), io::Error>) -> Poll<(), io::Error> {
+        match req {
+            multiplex::Frame::Message { message, .. } => self.inner.write(message),
+            _ => panic!("not a message frame"),
+        }
+    }
+
+    fn flush(&mut self) -> Poll<(), io::Error> {
+        self.inner.flush()
+    }
+}
+
+/// An "easy" multiplexed server.
+///
+/// This struct is an implementation of a server which takes a `FramedIo` (`T`)
+/// and dispatches all requests to a service (`S`) to be handled. Internally
+/// requests are multiplexed and dispatched/written appropriately over time.
+///
+/// Note that no streaming request/response bodies are supported with this
+/// server to help simplify generics and get off the ground running. If
+/// streaming bodies are desired then the top level `multiplex::Server` type can
+/// be used (which this is built on).
+pub struct EasyServer<S, T, I>
+    where S: Service<Request = I, Response = T::In, Error = io::Error> + 'static,
+          T: FramedIo<Out = Option<I>> + 'static,
+          T::In: 'static,
+          I: 'static,
+{
+    inner: multiplex::Server<MyService<S>,
+                             MyTransport<T, I>,
+                             Receiver<(), io::Error>>,
+}
+
+impl<S, T, I> EasyServer<S, T, I>
+    where S: Service<Request = I, Response = T::In, Error = io::Error> + 'static,
+          T: FramedIo<Out = Option<I>> + 'static,
+          T::In: 'static,
+          I: 'static,
+{
+    /// Instantiates a new multiplexed server.
+    ///
+    /// The returned server implements the `Future` trait and is used to
+    /// internally drive forward all requests for this given transport. The
+    /// `transport` provided is an instance of `FramedIo` where the requests are
+    /// dispatched to the `service` provided to get a response to write.
+    pub fn new(service: S, transport: T) -> EasyServer<S, T, I> {
+        EasyServer {
+            inner: multiplex::Server::new(MyService(service),
+                                          MyTransport::new(transport)),
+        }
+    }
+}
+
+impl<S, T, I> Future for EasyServer<S, T, I>
+    where S: Service<Request = I, Response = T::In, Error = io::Error> + 'static,
+          T: FramedIo<Out = Option<I>> + 'static,
+          T::In: 'static,
+          I: 'static,
+{
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<(), ()> {
+        self.inner.poll()
+    }
+}
+
+struct MyService<S>(S);
+
+impl<S: Service> Service for MyService<S> {
+    type Request = Message<S::Request, Body<(), io::Error>>;
+    type Response = Message<S::Response, Receiver<(), S::Error>>;
+    type Error = S::Error;
+    type Future = MyFuture<S::Future, Receiver<(), S::Error>>;
+
+    fn call(&self, req: Self::Request) -> Self::Future {
+        match req {
+            Message::WithoutBody(msg) => {
+                MyFuture(self.0.call(msg), marker::PhantomData)
+            }
+            Message::WithBody(..) => panic!("bodies not supported"),
+        }
+    }
+
+    fn poll_ready(&self) -> Async<()> {
+        self.0.poll_ready()
+    }
+}
+
+struct MyFuture<F, T>(F, marker::PhantomData<fn() -> T>);
+
+impl<F: Future, T> Future for MyFuture<F, T> {
+    type Item = Message<F::Item, T>;
+    type Error = F::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let item = try_ready!(self.0.poll());
+        Ok(Message::WithoutBody(item).into())
+    }
+}

--- a/src/easy/pipeline.rs
+++ b/src/easy/pipeline.rs
@@ -1,0 +1,178 @@
+//! An "easy" pipelining module
+//!
+//! This module is the same as the top-level `pipeline` module in this crate
+//! except that it has no support for streaming bodies. This in turn simplifies
+//! a number of generics and allows for protocols to easily get off the ground
+//! running.
+//!
+//! The API surface area of this module is the same as the top-level one, so no
+//! new functionality is introduced here. In fact all APIs here are built on top
+//! of the `pipeline` module itself, they just simplify the generics in play and
+//! such.
+
+use std::io;
+use std::marker;
+
+use futures::stream::Receiver;
+use futures::{self, Future, Async, Poll};
+use tokio_core::io::FramedIo;
+use tokio_core::reactor::Handle;
+use tokio_service::Service;
+
+use easy::EasyClient;
+use pipeline;
+use {Message, Body};
+
+/// The "easy" form of connecting a pipelined client.
+///
+/// This function takes an instance of the `tokio_core::io::FrameIo` trait as
+/// the `frames` argument, a `handle` to the event loop to connect on, and then
+/// returns the connected client.
+///
+/// The client returned implements the `Service` trait. This trait
+/// implementation allows sending requests to the transport provided and returns
+/// futures to the responses. All requests are automatically pipelined and
+/// managed internally.
+pub fn connect<F, T>(frames: F, handle: &Handle)
+    -> EasyClient<F::In, T>
+    where F: FramedIo<Out = Option<T>> + 'static,
+          T: 'static,
+          F::In: 'static,
+{
+    let frames = MyTransport(frames, marker::PhantomData);
+    EasyClient {
+        inner: pipeline::connect(futures::finished(frames), handle),
+    }
+}
+
+// Lifts an implementation of `FramedIo` to `pipeline::Transport` with no bodies
+struct MyTransport<F, T>(F, marker::PhantomData<fn() -> T>);
+
+impl<F, T> pipeline::Transport for MyTransport<F, T>
+    where F: FramedIo<Out = Option<T>> + 'static,
+          T: 'static,
+          F::In: 'static,
+{
+    type In = F::In;
+    type BodyIn = ();
+    type Out = T;
+    type BodyOut = ();
+    type Error = io::Error;
+
+    fn poll_read(&mut self) -> Async<()> {
+        self.0.poll_read()
+    }
+
+    fn read(&mut self) -> Poll<pipeline::Frame<T, (), io::Error>, io::Error> {
+        match try_ready!(self.0.read()) {
+            Some(msg) => {
+                Ok(pipeline::Frame::Message { message: msg, body: false }.into())
+            }
+            None => Ok(pipeline::Frame::Done.into()),
+        }
+    }
+
+    fn poll_write(&mut self) -> Async<()> {
+        self.0.poll_write()
+    }
+
+    fn write(&mut self, req: pipeline::Frame<F::In, (), io::Error>) -> Poll<(), io::Error> {
+        match req {
+            pipeline::Frame::Message { message, .. } => self.0.write(message),
+            _ => panic!("not a message frame"),
+        }
+    }
+
+    fn flush(&mut self) -> Poll<(), io::Error> {
+        self.0.flush()
+    }
+}
+
+/// An "easy" pipelined server.
+///
+/// This struct is an implementation of a server which takes a `FramedIo` (`T`)
+/// and dispatches all requests to a service (`S`) to be handled. Internally
+/// requests are pipelined and dispatched/written appropriately over time.
+///
+/// Note that no streaming request/response bodies are supported with this
+/// server to help simplify generics and get off the ground running. If
+/// streaming bodies are desired then the top level `pipeline::Server` type can
+/// be used (which this is built on).
+pub struct EasyServer<S, T, I>
+    where S: Service<Request = I, Response = T::In, Error = io::Error> + 'static,
+          T: FramedIo<Out = Option<I>> + 'static,
+          T::In: 'static,
+          I: 'static,
+{
+    inner: pipeline::Server<MyService<S>,
+                            MyTransport<T, I>,
+                            Receiver<(), io::Error>>,
+}
+
+impl<S, T, I> EasyServer<S, T, I>
+    where S: Service<Request = I, Response = T::In, Error = io::Error> + 'static,
+          T: FramedIo<Out = Option<I>> + 'static,
+          T::In: 'static,
+          I: 'static,
+{
+    /// Instantiates a new pipelined server.
+    ///
+    /// The returned server implements the `Future` trait and is used to
+    /// internally drive forward all requests for this given transport. The
+    /// `transport` provided is an instance of `FramedIo` where the requests are
+    /// dispatched to the `service` provided to get a response to write.
+    pub fn new(service: S, transport: T) -> EasyServer<S, T, I> {
+        EasyServer {
+            inner: pipeline::Server::new(MyService(service),
+                                         MyTransport(transport, marker::PhantomData)),
+        }
+    }
+}
+
+impl<S, T, I> Future for EasyServer<S, T, I>
+    where S: Service<Request = I, Response = T::In, Error = io::Error> + 'static,
+          T: FramedIo<Out = Option<I>> + 'static,
+          T::In: 'static,
+          I: 'static,
+{
+    type Item = ();
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<(), io::Error> {
+        self.inner.poll()
+    }
+}
+
+struct MyService<S>(S);
+
+impl<S: Service> Service for MyService<S> {
+    type Request = Message<S::Request, Body<(), io::Error>>;
+    type Response = Message<S::Response, Receiver<(), S::Error>>;
+    type Error = S::Error;
+    type Future = MyFuture<S::Future, Receiver<(), S::Error>>;
+
+    fn call(&self, req: Self::Request) -> Self::Future {
+        match req {
+            Message::WithoutBody(msg) => {
+                MyFuture(self.0.call(msg), marker::PhantomData)
+            }
+            Message::WithBody(..) => panic!("bodies not supported"),
+        }
+    }
+
+    fn poll_ready(&self) -> Async<()> {
+        self.0.poll_ready()
+    }
+}
+
+struct MyFuture<F, T>(F, marker::PhantomData<fn() -> T>);
+
+impl<F: Future, T> Future for MyFuture<F, T> {
+    type Item = Message<F::Item, T>;
+    type Error = F::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let item = try_ready!(self.0.poll());
+        Ok(Message::WithoutBody(item).into())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod client;
 pub mod multiplex;
 pub mod pipeline;
 pub mod server;
+pub mod easy;
 
 mod body;
 mod error;


### PR DESCRIPTION
This commit adds a new module to `tokio-proto`, `easy`, which like
`tokio_core::easy` is intended to help you get off the ground running quickly
for any particular protocol.

This module mirrors the API of the pipeline/multiplex modules with a
server/client implementation that's built on top of the actual server/client in
the top-level modules. The types and generics, however, are greatly reduced to
help work with them ergonomically.