### PR TITLE
Make simple pipeline ClientService public

### DIFF
--- a/src/simple/pipeline/client.rs
+++ b/src/simple/pipeline/client.rs
@@ -88,6 +88,7 @@ impl<T, P> streaming::pipeline::ClientProto<T> for LiftProto<P> where
     }
 }
 
+/// Client `Service` for simple pipeline protocols
 pub struct ClientService<T, P> where T: 'static, P: ClientProto<T> {
     inner: <LiftProto<P> as BindClient<StreamingPipeline<MyStream<P::Error>>, T>>::BindClient
 }

--- a/src/simple/pipeline/mod.rs
+++ b/src/simple/pipeline/mod.rs
@@ -4,6 +4,7 @@
 
 mod client;
 pub use self::client::ClientProto;
+pub use self::client::ClientService;
 
 mod server;
 pub use self::server::ServerProto;


### PR DESCRIPTION
When creating a simple pipeline client, the response type from
TcpClient::connect() was private. Documentation was also added to the
ClientService to pass the linting.

Fixes #81