### PR TITLE
fix unimplemented when client service is dropped

### DIFF
--- a/src/streaming/pipeline/advanced.rs
+++ b/src/streaming/pipeline/advanced.rs
@@ -272,10 +272,8 @@ impl<T> Pipeline<T> where T: Dispatch {
                 }
                 Async::Ready(None) => {
                     trace!("   --> got None");
-                    // The service is done with the connection. In this case, a
-                    // `Done` frame should be written to the transport and the
-                    // transport should start shutting down.
-                    unimplemented!();
+                    // The service is done with the connection.
+                    break;
                 }
                 // Nothing to dispatch
                 Async::NotReady => break,


### PR DESCRIPTION
It seems to me that just breaking in the loop is the right thing. This will let the service still read out any frames, letting responses finish. And since the service is dropped, the socket will be dropped and everything should just work. I hope.

Closes #71 