### PR TITLE
Hook error frames into non-streaming protocols

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@
 //!
 //! impl Codec for IntCodec {
 //!     type In = u64;
-//!     type Out = u64;
+//!     type Out = io::Result<u64>;
 //!
 //!     // Attempt to decode a message from the given buffer if a complete
 //!     // message is available; returns `Ok(None)` if the buffer does not yet
@@ -123,8 +123,8 @@
 //!         Ok(parse_u64(buf.drain_to(amt).as_slice())?)
 //!     }
 //!
-//!     fn encode(&mut self, item: u64, into: &mut Vec<u8>) -> io::Result<()> {
-//!         writeln!(into, "{}", item);
+//!     fn encode(&mut self, item: io::Result<u64>, into: &mut Vec<u8>) -> io::Result<()> {
+//!         writeln!(into, "{}", item.unwrap());
 //!         Ok(())
 //!     }
 //! }

--- a/src/simple/multiplex/client.rs
+++ b/src/simple/multiplex/client.rs
@@ -1,15 +1,14 @@
 use BindClient;
 use super::{RequestId, Multiplex};
-use super::lift::{LiftBind, LiftTransport};
-use simple::LiftProto;
+use simple::{LiftProto, LiftBind, FromTransport};
 
 use std::io;
 
 use streaming::{self, Message};
-use streaming::multiplex::StreamingMultiplex;
+use streaming::multiplex::{self, Frame, StreamingMultiplex};
 use tokio_core::reactor::Handle;
 use tokio_service::Service;
-use futures::{stream, Stream, Sink, Future, IntoFuture, Poll};
+use futures::{stream, Stream, Sink, Future, IntoFuture, Poll, StartSend, AsyncSink};
 
 type MyStream<E> = stream::Empty<(), E>;
 
@@ -37,7 +36,7 @@ pub trait ClientProto<T: 'static>: 'static {
     /// together with a `Codec`; in that case, the transport type is
     /// `Framed<T, YourCodec>`. See the crate docs for an example.
     type Transport: 'static +
-        Stream<Item = (RequestId, Self::Response), Error = io::Error> +
+        Stream<Item = (RequestId, Result<Self::Response, Self::Error>), Error = io::Error> +
         Sink<SinkItem = (RequestId, Self::Request), SinkError = io::Error>;
 
     /// A future for initializing a transport from an I/O object.
@@ -81,13 +80,52 @@ impl<T, P> streaming::multiplex::ClientProto<T> for LiftProto<P> where
 
     type Error = P::Error;
 
-    type Transport = LiftTransport<P::Transport, P::Error>;
-    type BindTransport = LiftBind<T, <P::BindTransport as IntoFuture>::Future, P::Error>;
+    type Transport = LiftTransport<T, P>;
+    type BindTransport = LiftBind<<P::BindTransport as IntoFuture>::Future, Self::Transport>;
 
     fn bind_transport(&self, io: T) -> Self::BindTransport {
         LiftBind::lift(ClientProto::bind_transport(self.lower(), io).into_future())
     }
 }
+
+// Lifts an implementation of RPC-style transport to streaming-style transport
+pub struct LiftTransport<T: 'static, P: ClientProto<T>>(P::Transport);
+
+impl<T: 'static, P: ClientProto<T>> Stream for LiftTransport<T, P> {
+    type Item = Frame<P::Response, (), P::Error>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, io::Error> {
+        Ok(try_ready!(self.0.poll()).map(super::lift_msg_result).into())
+    }
+}
+
+impl<T: 'static, P: ClientProto<T>> Sink for LiftTransport<T, P> {
+    type SinkItem = Frame<P::Request, (), P::Error>;
+    type SinkError = io::Error;
+
+    fn start_send(&mut self, msg: Self::SinkItem) -> StartSend<Self::SinkItem, io::Error> {
+        match try!(self.0.start_send(super::lower_msg(msg))) {
+            AsyncSink::Ready => Ok(AsyncSink::Ready),
+            AsyncSink::NotReady(msg) => {
+                Ok(AsyncSink::NotReady(super::lift_msg(msg)))
+            }
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), io::Error> {
+        self.0.poll_complete()
+    }
+}
+
+impl<T: 'static, P: ClientProto<T>> multiplex::Transport<()> for LiftTransport<T, P> {}
+
+impl<T: 'static, P: ClientProto<T>> FromTransport<P::Transport> for LiftTransport<T, P> {
+    fn from_transport(transport: P::Transport) -> LiftTransport<T, P> {
+        LiftTransport(transport)
+    }
+}
+
 
 /// Client `Service` for simple multiplex protocols
 pub struct ClientService<T, P> where T: 'static, P: ClientProto<T> {

--- a/src/simple/multiplex/mod.rs
+++ b/src/simple/multiplex/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! See the crate-level docs for an overview.
 
+use streaming::multiplex::Frame;
+
 mod client;
 pub use self::client::ClientProto;
 pub use self::client::ClientService;
@@ -18,101 +20,37 @@ pub type RequestId = u64;
 /// implement the `ClientProto` or `ServerProto` traits in this module.
 pub struct Multiplex;
 
-// This is a submodule so that `LiftTransport` can be marked `pub`, to satisfy
-// the no-private-in-public checker.
-mod lift {
-    use std::io;
-    use std::marker::PhantomData;
-
-    use super::RequestId;
-    use streaming::multiplex::{Frame, Transport};
-    use futures::{Future, Stream, Sink, StartSend, Poll, Async, AsyncSink};
-
-    // Lifts an implementation of RPC-style transport to streaming-style transport
-    pub struct LiftTransport<T, E>(pub T, pub PhantomData<E>);
-
-    // Lifts the Bind from the underlying transport
-    pub struct LiftBind<A, F, E> {
-        fut: F,
-        marker: PhantomData<(A, E)>,
+fn lift_msg_result<T, E>(msg: (RequestId, Result<T, E>)) -> Frame<T, (), E> {
+    let (id, msg) = msg;
+    match msg {
+        Ok(msg) => Frame::Message { message: msg, body: false, solo: false, id: id },
+        Err(err) => Frame::Error { error: err, id: id },
     }
+}
 
-    impl<T, InnerItem, E> Stream for LiftTransport<T, E> where
-        E: 'static,
-        T: Stream<Item = (RequestId, InnerItem), Error = io::Error>,
-    {
-        type Item = Frame<InnerItem, (), E>;
-        type Error = io::Error;
-
-        fn poll(&mut self) -> Poll<Option<Self::Item>, io::Error> {
-            let (id, msg) = match try_ready!(self.0.poll()) {
-                Some(msg) => msg,
-                None => return Ok(None.into()),
-            };
-            Ok(Some(Frame::Message {
-                message: msg,
-                body: false,
-                solo: false,
-                id: id,
-            }).into())
+fn lower_msg_result<T, E>(msg: Frame<T, (), E>) -> (RequestId, Result<T, E>) {
+    match msg {
+        Frame::Message { message, body, solo, id } => {
+            if !body && !solo { return (id, Ok(message)) }
         }
+        Frame::Error { error, id } => return (id, Err(error)),
+        _ => {}
     }
+    panic!("Encountered a streaming body in a non-streaming protocol")
+}
 
-    impl<T, InnerSink, E> Sink for LiftTransport<T, E> where
-        E: 'static,
-        T: Sink<SinkItem = (RequestId, InnerSink), SinkError = io::Error>
-    {
-        type SinkItem = Frame<InnerSink, (), E>;
-        type SinkError = io::Error;
+fn lift_msg<T, E>(msg: (RequestId, T)) -> Frame<T, (), E> {
+    Frame::Message { message: msg.1, body: false, solo: false, id: msg.0 }
+}
 
-        fn start_send(&mut self, request: Self::SinkItem)
-                      -> StartSend<Self::SinkItem, io::Error> {
-            if let Frame::Message { message, id, body, solo } = request {
-                if !body && !solo {
-                    match try!(self.0.start_send((id, message))) {
-                        AsyncSink::Ready => return Ok(AsyncSink::Ready),
-                        AsyncSink::NotReady((id, msg)) => {
-                            let msg = Frame::Message {
-                                message: msg,
-                                id: id,
-                                body: false,
-                                solo: false,
-                            };
-                            return Ok(AsyncSink::NotReady(msg))
-                        }
-                    }
-                }
-            }
-            Err(io::Error::new(io::ErrorKind::Other, "no support for streaming"))
+fn lower_msg<T, E>(msg: Frame<T, (), E>) -> (RequestId, T) {
+    match msg {
+        Frame::Message { message, body, solo, id } => {
+            if !body && !solo { return (id, message) }
         }
-
-        fn poll_complete(&mut self) -> Poll<(), io::Error> {
-            self.0.poll_complete()
-        }
+        Frame::Error { .. } =>
+            panic!("Encountered unexpected error frame in a non-streaming protocol"),
+        _ => {}
     }
-
-    impl<T, InnerItem, InnerSink, E> Transport<()> for LiftTransport<T, E> where
-        E: 'static,
-        T: 'static,
-        T: Stream<Item = (RequestId, InnerItem), Error = io::Error>,
-        T: Sink<SinkItem = (RequestId, InnerSink), SinkError = io::Error>
-    {}
-
-    impl<A, F, E> LiftBind<A, F, E> {
-        pub fn lift(f: F) -> LiftBind<A, F, E> {
-            LiftBind {
-                fut: f,
-                marker: PhantomData,
-            }
-        }
-    }
-
-    impl<A, F, E> Future for LiftBind<A, F, E> where F: Future<Error = io::Error> {
-        type Item = LiftTransport<F::Item, E>;
-        type Error = io::Error;
-
-        fn poll(&mut self) -> Poll<Self::Item, io::Error> {
-            Ok(Async::Ready(LiftTransport(try_ready!(self.fut.poll()), PhantomData)))
-        }
-    }
+    panic!("Encountered a streaming body in a non-streaming protocol");
 }

--- a/src/simple/multiplex/server.rs
+++ b/src/simple/multiplex/server.rs
@@ -3,14 +3,13 @@ use std::marker;
 
 use BindServer;
 use super::{RequestId, Multiplex};
-use super::lift::{LiftBind, LiftTransport};
-use simple::LiftProto;
+use simple::{LiftProto, LiftBind, FromTransport};
 
 use streaming::{self, Message};
-use streaming::multiplex::StreamingMultiplex;
+use streaming::multiplex::{self, Frame, StreamingMultiplex};
 use tokio_core::reactor::Handle;
 use tokio_service::Service;
-use futures::{stream, Stream, Sink, Future, IntoFuture, Poll};
+use futures::{stream, Stream, Sink, Future, IntoFuture, Poll, StartSend, AsyncSink};
 
 type MyStream<E> = stream::Empty<(), E>;
 
@@ -39,7 +38,7 @@ pub trait ServerProto<T: 'static>: 'static {
     /// `Framed<T, YourCodec>`. See the crate docs for an example.
     type Transport: 'static +
         Stream<Item = (RequestId, Self::Request), Error = io::Error> +
-        Sink<SinkItem = (RequestId, Self::Response), SinkError = io::Error>;
+        Sink<SinkItem = (RequestId, Result<Self::Response, Self::Error>), SinkError = io::Error>;
 
     /// A future for initializing a transport from an I/O object.
     ///
@@ -71,7 +70,7 @@ impl<T: 'static, P: ServerProto<T>> BindServer<Multiplex, T> for P {
     }
 }
 
-impl<T, P> streaming::multiplex::ServerProto<T> for LiftProto<P> where
+impl<T, P> multiplex::ServerProto<T> for LiftProto<P> where
     T: 'static, P: ServerProto<T>
 {
     type Request = P::Request;
@@ -82,11 +81,49 @@ impl<T, P> streaming::multiplex::ServerProto<T> for LiftProto<P> where
 
     type Error = P::Error;
 
-    type Transport = LiftTransport<P::Transport, P::Error>;
-    type BindTransport = LiftBind<T, <P::BindTransport as IntoFuture>::Future, P::Error>;
+    type Transport = LiftTransport<T, P>;
+    type BindTransport = LiftBind<<P::BindTransport as IntoFuture>::Future, Self::Transport>;
 
     fn bind_transport(&self, io: T) -> Self::BindTransport {
         LiftBind::lift(ServerProto::bind_transport(self.lower(), io).into_future())
+    }
+}
+
+// Lifts an implementation of RPC-style transport to streaming-style transport
+pub struct LiftTransport<T: 'static, P: ServerProto<T>>(P::Transport);
+
+impl<T: 'static, P: ServerProto<T>> Stream for LiftTransport<T, P> {
+    type Item = Frame<P::Request, (), P::Error>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, io::Error> {
+        Ok(try_ready!(self.0.poll()).map(super::lift_msg).into())
+    }
+}
+
+impl<T: 'static, P: ServerProto<T>> Sink for LiftTransport<T, P> {
+    type SinkItem = Frame<P::Response, (), P::Error>;
+    type SinkError = io::Error;
+
+    fn start_send(&mut self, msg: Self::SinkItem) -> StartSend<Self::SinkItem, io::Error> {
+        match try!(self.0.start_send(super::lower_msg_result(msg))) {
+            AsyncSink::Ready => Ok(AsyncSink::Ready),
+            AsyncSink::NotReady(msg) => {
+                Ok(AsyncSink::NotReady(super::lift_msg_result(msg)))
+            }
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), io::Error> {
+        self.0.poll_complete()
+    }
+}
+
+impl<T: 'static, P: ServerProto<T>> multiplex::Transport<()> for LiftTransport<T, P> {}
+
+impl<T: 'static, P: ServerProto<T>> FromTransport<P::Transport> for LiftTransport<T, P> {
+    fn from_transport(transport: P::Transport) -> LiftTransport<T, P> {
+        LiftTransport(transport)
     }
 }
 

--- a/src/simple/pipeline/mod.rs
+++ b/src/simple/pipeline/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! See the crate-level docs for an overview.
 
+use streaming::pipeline::Frame;
+
 mod client;
 pub use self::client::ClientProto;
 pub use self::client::ClientService;
@@ -15,80 +17,36 @@ pub use self::server::ServerProto;
 /// implement the `ClientProto` or `ServerProto` traits in this module.
 pub struct Pipeline;
 
-// This is a submodule so that `LiftTransport` can be marked `pub`, to satisfy
-// the no-private-in-public checker.
-mod lift {
-    use std::io;
-    use std::marker::PhantomData;
-
-    use streaming::pipeline::{Frame, Transport};
-    use futures::{Future, Stream, Sink, StartSend, Poll, Async, AsyncSink};
-
-    // Lifts an implementation of RPC-style transport to streaming-style transport
-    pub struct LiftTransport<T, E>(pub T, pub PhantomData<E>);
-
-    // Lifts the Bind from the underlying transport
-    pub struct LiftBind<A, F, E> {
-        fut: F,
-        marker: PhantomData<(A, E)>,
+fn lift_msg_result<T, E>(msg: Result<T, E>) -> Frame<T, (), E> {
+    match msg {
+        Ok(msg) => Frame::Message { message: msg, body: false },
+        Err(err) => Frame::Error { error: err },
     }
+}
 
-    impl<E, T: Stream<Error = io::Error>> Stream for LiftTransport<T, E> {
-        type Item = Frame<T::Item, (), E>;
-        type Error = io::Error;
-
-        fn poll(&mut self) -> Poll<Option<Self::Item>, io::Error> {
-            let item = try_ready!(self.0.poll());
-            Ok(item.map(|msg| {
-                Frame::Message { message: msg, body: false }
-            }).into())
+fn lower_msg_result<T, E>(msg: Frame<T, (), E>) -> Result<T, E> {
+    match msg {
+        Frame::Message { message, body } => {
+            if !body { return Ok(message) }
         }
+        Frame::Error { error } => return Err(error),
+        _ => {}
     }
+    panic!("Encountered a streaming body in a non-streaming protocol")
+}
 
-    impl<E, T: Sink<SinkError = io::Error>> Sink for LiftTransport<T, E> {
-        type SinkItem = Frame<T::SinkItem, (), E>;
-        type SinkError = io::Error;
+fn lift_msg<T, E>(msg: T) -> Frame<T, (), E> {
+    Frame::Message { message: msg, body: false }
+}
 
-        fn start_send(&mut self, request: Self::SinkItem)
-                      -> StartSend<Self::SinkItem, io::Error> {
-            if let Frame::Message { message, body } = request {
-                if !body {
-                    match try!(self.0.start_send(message)) {
-                        AsyncSink::Ready => return Ok(AsyncSink::Ready),
-                        AsyncSink::NotReady(msg) => {
-                            let msg = Frame::Message { message: msg, body: false };
-                            return Ok(AsyncSink::NotReady(msg))
-                        }
-                    }
-                }
-            }
-            Err(io::Error::new(io::ErrorKind::Other, "no support for streaming"))
+fn lower_msg<T, E>(msg: Frame<T, (), E>) -> T {
+    match msg {
+        Frame::Message { message, body } => {
+            if !body { return message }
         }
-
-        fn poll_complete(&mut self) -> Poll<(), io::Error> {
-            self.0.poll_complete()
-        }
+        Frame::Error { .. } =>
+            panic!("Encountered unexpected error frame in a non-streaming protocol"),
+        _ => {}
     }
-
-    impl<T, E: 'static> Transport for LiftTransport<T, E>
-        where T: 'static + Stream<Error = io::Error> + Sink<SinkError = io::Error>
-    {}
-
-    impl<A, F, E> LiftBind<A, F, E> {
-        pub fn lift(f: F) -> LiftBind<A, F, E> {
-            LiftBind {
-                fut: f,
-                marker: PhantomData,
-            }
-        }
-    }
-
-    impl<A, F, E> Future for LiftBind<A, F, E> where F: Future<Error = io::Error> {
-        type Item = LiftTransport<F::Item, E>;
-        type Error = io::Error;
-
-        fn poll(&mut self) -> Poll<Self::Item, io::Error> {
-            Ok(Async::Ready(LiftTransport(try_ready!(self.fut.poll()), PhantomData)))
-        }
-    }
+    panic!("Encountered a streaming body in a non-streaming protocol");
 }

--- a/src/simple/pipeline/server.rs
+++ b/src/simple/pipeline/server.rs
@@ -3,14 +3,13 @@ use std::marker;
 
 use BindServer;
 use super::Pipeline;
-use super::lift::{LiftBind, LiftTransport};
-use simple::LiftProto;
+use simple::{LiftProto, LiftBind, FromTransport};
 
 use streaming::{self, Message};
-use streaming::pipeline::StreamingPipeline;
+use streaming::pipeline::{self, Frame, StreamingPipeline};
 use tokio_core::reactor::Handle;
 use tokio_service::Service;
-use futures::{stream, Stream, Sink, Future, IntoFuture, Poll};
+use futures::{stream, Stream, Sink, Future, IntoFuture, Poll, StartSend, AsyncSink};
 
 type MyStream<E> = stream::Empty<(), E>;
 
@@ -39,7 +38,7 @@ pub trait ServerProto<T: 'static>: 'static {
     /// `Framed<T, YourCodec>`. See the crate docs for an example.
     type Transport: 'static +
         Stream<Item = Self::Request, Error = io::Error> +
-        Sink<SinkItem = Self::Response, SinkError = io::Error>;
+        Sink<SinkItem = Result<Self::Response, Self::Error>, SinkError = io::Error>;
 
     /// A future for initializing a transport from an I/O object.
     ///
@@ -82,11 +81,49 @@ impl<T, P> streaming::pipeline::ServerProto<T> for LiftProto<P> where
 
     type Error = P::Error;
 
-    type Transport = LiftTransport<P::Transport, P::Error>;
-    type BindTransport = LiftBind<T, <P::BindTransport as IntoFuture>::Future, P::Error>;
+    type Transport = LiftTransport<T, P>;
+    type BindTransport = LiftBind<<P::BindTransport as IntoFuture>::Future, Self::Transport>;
 
     fn bind_transport(&self, io: T) -> Self::BindTransport {
         LiftBind::lift(ServerProto::bind_transport(self.lower(), io).into_future())
+    }
+}
+
+// Lifts an implementation of RPC-style transport to streaming-style transport
+pub struct LiftTransport<T: 'static, P: ServerProto<T>>(P::Transport);
+
+impl<T: 'static, P: ServerProto<T>> Stream for LiftTransport<T, P> {
+    type Item = Frame<P::Request, (), P::Error>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, io::Error> {
+        Ok(try_ready!(self.0.poll()).map(super::lift_msg).into())
+    }
+}
+
+impl<T: 'static, P: ServerProto<T>> Sink for LiftTransport<T, P> {
+    type SinkItem = Frame<P::Response, (), P::Error>;
+    type SinkError = io::Error;
+
+    fn start_send(&mut self, msg: Self::SinkItem) -> StartSend<Self::SinkItem, io::Error> {
+        match try!(self.0.start_send(super::lower_msg_result(msg))) {
+            AsyncSink::Ready => Ok(AsyncSink::Ready),
+            AsyncSink::NotReady(msg) => {
+                Ok(AsyncSink::NotReady(super::lift_msg_result(msg)))
+            }
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), io::Error> {
+        self.0.poll_complete()
+    }
+}
+
+impl<T: 'static, P: ServerProto<T>> pipeline::Transport for LiftTransport<T, P> {}
+
+impl<T: 'static, P: ServerProto<T>> FromTransport<P::Transport> for LiftTransport<T, P> {
+    fn from_transport(transport: P::Transport) -> LiftTransport<T, P> {
+        LiftTransport(transport)
     }
 }
 


### PR DESCRIPTION
This commit refactors non-streaming protocols to allow for transports
with error frames, and to properly hook that into dispatch.

Closes #97