### PR TITLE
Format code with rustfmt

### DIFF
--- a/src/buffer_one.rs
+++ b/src/buffer_one.rs
@@ -49,7 +49,8 @@ impl<S: Sink> BufferOne<S> {
             }
 
             // Unpark any pending tasks
-            self.task.take()
+            self.task
+                .take()
                 .map(|t| t.unpark());
         }
 
@@ -58,7 +59,9 @@ impl<S: Sink> BufferOne<S> {
 }
 
 // Forwarding impl of Stream from the underlying sink
-impl<S> Stream for BufferOne<S> where S: Sink + Stream {
+impl<S> Stream for BufferOne<S>
+    where S: Sink + Stream
+{
     type Item = S::Item;
     type Error = S::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,8 +268,8 @@ pub trait BindClient<Kind, T: 'static>: 'static {
 
     /// The bound service.
     type BindClient: Service<Request = Self::ServiceRequest,
-                             Response = Self::ServiceResponse,
-                             Error = Self::ServiceError>;
+            Response = Self::ServiceResponse,
+            Error = Self::ServiceError>;
 
     /// Bind an I/O object as a service.
     fn bind_client(&self, handle: &Handle, io: T) -> Self::BindClient;

--- a/src/simple/multiplex/mod.rs
+++ b/src/simple/multiplex/mod.rs
@@ -37,9 +37,9 @@ mod lift {
         marker: PhantomData<(A, E)>,
     }
 
-    impl<T, InnerItem, E> Stream for LiftTransport<T, E> where
-        E: 'static,
-        T: Stream<Item = (RequestId, InnerItem), Error = io::Error>,
+    impl<T, InnerItem, E> Stream for LiftTransport<T, E>
+        where E: 'static,
+              T: Stream<Item = (RequestId, InnerItem), Error = io::Error>
     {
         type Item = Frame<InnerItem, (), E>;
         type Error = io::Error;
@@ -50,23 +50,23 @@ mod lift {
                 None => return Ok(None.into()),
             };
             Ok(Some(Frame::Message {
-                message: msg,
-                body: false,
-                solo: false,
-                id: id,
-            }).into())
+                    message: msg,
+                    body: false,
+                    solo: false,
+                    id: id,
+                })
+                .into())
         }
     }
 
-    impl<T, InnerSink, E> Sink for LiftTransport<T, E> where
-        E: 'static,
-        T: Sink<SinkItem = (RequestId, InnerSink), SinkError = io::Error>
+    impl<T, InnerSink, E> Sink for LiftTransport<T, E>
+        where E: 'static,
+              T: Sink<SinkItem = (RequestId, InnerSink), SinkError = io::Error>
     {
         type SinkItem = Frame<InnerSink, (), E>;
         type SinkError = io::Error;
 
-        fn start_send(&mut self, request: Self::SinkItem)
-                      -> StartSend<Self::SinkItem, io::Error> {
+        fn start_send(&mut self, request: Self::SinkItem) -> StartSend<Self::SinkItem, io::Error> {
             if let Frame::Message { message, id, body, solo } = request {
                 if !body && !solo {
                     match try!(self.0.start_send((id, message))) {
@@ -78,7 +78,7 @@ mod lift {
                                 body: false,
                                 solo: false,
                             };
-                            return Ok(AsyncSink::NotReady(msg))
+                            return Ok(AsyncSink::NotReady(msg));
                         }
                     }
                 }
@@ -91,12 +91,13 @@ mod lift {
         }
     }
 
-    impl<T, InnerItem, InnerSink, E> Transport<()> for LiftTransport<T, E> where
-        E: 'static,
-        T: 'static,
-        T: Stream<Item = (RequestId, InnerItem), Error = io::Error>,
-        T: Sink<SinkItem = (RequestId, InnerSink), SinkError = io::Error>
-    {}
+    impl<T, InnerItem, InnerSink, E> Transport<()> for LiftTransport<T, E>
+        where E: 'static,
+              T: 'static,
+              T: Stream<Item = (RequestId, InnerItem), Error = io::Error>,
+              T: Sink<SinkItem = (RequestId, InnerSink), SinkError = io::Error>
+    {
+}
 
     impl<A, F, E> LiftBind<A, F, E> {
         pub fn lift(f: F) -> LiftBind<A, F, E> {
@@ -107,7 +108,9 @@ mod lift {
         }
     }
 
-    impl<A, F, E> Future for LiftBind<A, F, E> where F: Future<Error = io::Error> {
+    impl<A, F, E> Future for LiftBind<A, F, E>
+        where F: Future<Error = io::Error>
+    {
         type Item = LiftTransport<F::Item, E>;
         type Error = io::Error;
 

--- a/src/simple/multiplex/server.rs
+++ b/src/simple/multiplex/server.rs
@@ -37,9 +37,7 @@ pub trait ServerProto<T: 'static>: 'static {
     /// An easy way to build a transport is to use `tokio_core::io::Framed`
     /// together with a `Codec`; in that case, the transport type is
     /// `Framed<T, YourCodec>`. See the crate docs for an example.
-    type Transport: 'static +
-        Stream<Item = (RequestId, Self::Request), Error = io::Error> +
-        Sink<SinkItem = (RequestId, Self::Response), SinkError = io::Error>;
+    type Transport: 'static + Stream<Item = (RequestId, Self::Request), Error = io::Error> + Sink<SinkItem = (RequestId, Self::Response), SinkError = io::Error>;
 
     /// A future for initializing a transport from an I/O object.
     ///
@@ -71,8 +69,9 @@ impl<T: 'static, P: ServerProto<T>> BindServer<Multiplex, T> for P {
     }
 }
 
-impl<T, P> streaming::multiplex::ServerProto<T> for LiftProto<P> where
-    T: 'static, P: ServerProto<T>
+impl<T, P> streaming::multiplex::ServerProto<T> for LiftProto<P>
+    where T: 'static,
+          P: ServerProto<T>
 {
     type Request = P::Request;
     type RequestBody = ();
@@ -100,9 +99,7 @@ impl<S: Service> Service for LiftService<S> {
 
     fn call(&mut self, req: Self::Request) -> Self::Future {
         match req {
-            Message::WithoutBody(msg) => {
-                LiftFuture(self.0.call(msg), marker::PhantomData)
-            }
+            Message::WithoutBody(msg) => LiftFuture(self.0.call(msg), marker::PhantomData),
             Message::WithBody(..) => panic!("bodies not supported"),
         }
     }

--- a/src/simple/pipeline/server.rs
+++ b/src/simple/pipeline/server.rs
@@ -37,9 +37,7 @@ pub trait ServerProto<T: 'static>: 'static {
     /// An easy way to build a transport is to use `tokio_core::io::Framed`
     /// together with a `Codec`; in that case, the transport type is
     /// `Framed<T, YourCodec>`. See the crate docs for an example.
-    type Transport: 'static +
-        Stream<Item = Self::Request, Error = io::Error> +
-        Sink<SinkItem = Self::Response, SinkError = io::Error>;
+    type Transport: 'static + Stream<Item = Self::Request, Error = io::Error> + Sink<SinkItem = Self::Response, SinkError = io::Error>;
 
     /// A future for initializing a transport from an I/O object.
     ///
@@ -71,8 +69,9 @@ impl<T: 'static, P: ServerProto<T>> BindServer<Pipeline, T> for P {
     }
 }
 
-impl<T, P> streaming::pipeline::ServerProto<T> for LiftProto<P> where
-    T: 'static, P: ServerProto<T>
+impl<T, P> streaming::pipeline::ServerProto<T> for LiftProto<P>
+    where T: 'static,
+          P: ServerProto<T>
 {
     type Request = P::Request;
     type RequestBody = ();
@@ -100,9 +99,7 @@ impl<S: Service> Service for LiftService<S> {
 
     fn call(&mut self, req: Self::Request) -> Self::Future {
         match req {
-            Message::WithoutBody(msg) => {
-                LiftFuture(self.0.call(msg), marker::PhantomData)
-            }
+            Message::WithoutBody(msg) => LiftFuture(self.0.call(msg), marker::PhantomData),
             Message::WithBody(..) => panic!("bodies not supported"),
         }
     }

--- a/src/streaming/multiplex/advanced.rs
+++ b/src/streaming/multiplex/advanced.rs
@@ -15,19 +15,18 @@ use super::frame_buf::{FrameBuf, FrameDeque};
 use super::{Frame, RequestId, Transport};
 use buffer_one::BufferOne;
 
-/*
- * TODO:
- *
- * - Handle errors correctly
- *    * When the FramedIo returns an error, how is it handled?
- *    * Is it sent to the dispatch?
- *    * Is it sent to the body?
- *    * What happens if there are in-flight *in* bodies
- *    * What happens if the out message is buffered?
- * - [BUG] Can only poll from body sender FutureSender in `flush`
- * - Move constants to configuration settings
- *
- */
+// TODO:
+//
+// - Handle errors correctly
+//    * When the FramedIo returns an error, how is it handled?
+//    * Is it sent to the dispatch?
+//    * Is it sent to the body?
+//    * What happens if there are in-flight *in* bodies
+//    * What happens if the out message is buffered?
+// - [BUG] Can only poll from body sender FutureSender in `flush`
+// - Move constants to configuration settings
+//
+//
 
 /// The max number of buffered frames that the connection can support. Once
 /// this number is reached.
@@ -40,7 +39,9 @@ const MAX_BUFFERED_FRAMES: usize = 128;
 /// Provides protocol multiplexing functionality in a generic way over clients
 /// and servers. Used internally by `multiplex::Client` and
 /// `multiplex::Server`.
-pub struct Multiplex<T> where T: Dispatch {
+pub struct Multiplex<T>
+    where T: Dispatch
+{
     // True as long as the connection has more request frames to read.
     run: bool,
 
@@ -160,32 +161,37 @@ pub trait Dispatch {
 
     /// Transport type
     type Transport: Transport<Self::BodyOut,
-                              Item = Frame<Self::Out, Self::BodyOut, Self::Error>,
-                              SinkItem = Frame<Self::In, Self::BodyIn, Self::Error>>;
+              Item = Frame<Self::Out, Self::BodyOut, Self::Error>,
+              SinkItem = Frame<Self::In, Self::BodyIn, Self::Error>>;
 
     /// Mutable reference to the transport
     fn transport(&mut self) -> &mut Self::Transport;
 
     /// Poll the next available message
-    fn poll(&mut self) -> Poll<Option<MultiplexMessage<Self::In, Self::Stream, Self::Error>>, io::Error>;
+    fn poll(&mut self)
+            -> Poll<Option<MultiplexMessage<Self::In, Self::Stream, Self::Error>>, io::Error>;
 
     /// The `Dispatch` is ready to accept another message
     fn poll_ready(&self) -> Async<()>;
 
     /// Process an out message
-    fn dispatch(&mut self, message: MultiplexMessage<Self::Out, Body<Self::BodyOut, Self::Error>, Self::Error>) -> io::Result<()>;
+    fn dispatch(&mut self,
+                message: MultiplexMessage<Self::Out,
+                                          Body<Self::BodyOut, Self::Error>,
+                                          Self::Error>)
+                -> io::Result<()>;
 
     /// Cancel interest in the exchange identified by RequestId
     fn cancel(&mut self, request_id: RequestId) -> io::Result<()>;
 }
 
-/*
- *
- * ===== impl Multiplex =====
- *
- */
+// ===== impl Multiplex =====
+//
+//
 
-impl<T> Multiplex<T> where T: Dispatch {
+impl<T> Multiplex<T>
+    where T: Dispatch
+{
     /// Create a new pipeline `Multiplex` dispatcher with the given service and
     /// transport
     pub fn new(dispatch: T) -> Multiplex<T> {
@@ -329,8 +335,7 @@ impl<T> Multiplex<T> where T: Dispatch {
                            message: Message<T::Out, Body<T::BodyOut, T::Error>>,
                            body: Option<mpsc::Sender<Result<T::BodyOut, T::Error>>>,
                            solo: bool)
-                           -> io::Result<()>
-    {
+                           -> io::Result<()> {
         trace!("   --> process message; body={:?}", body.is_some());
 
         match self.exchanges.entry(id) {
@@ -367,9 +372,7 @@ impl<T> Multiplex<T> where T: Dispatch {
                     assert!(self.dispatch_deque.is_empty());
 
                     // Create the exchange state
-                    let mut exchange = Exchange::new(
-                        Request::Out(None),
-                        self.frame_buf.deque());
+                    let mut exchange = Exchange::new(Request::Out(None), self.frame_buf.deque());
 
                     exchange.out_body = body;
 
@@ -393,9 +396,8 @@ impl<T> Multiplex<T> where T: Dispatch {
                     self.blocked_on_dispatch = true;
 
                     // Create the exchange state, including the buffered message
-                    let mut exchange = Exchange::new(
-                        Request::Out(Some(message)),
-                        self.frame_buf.deque());
+                    let mut exchange = Exchange::new(Request::Out(Some(message)),
+                                                     self.frame_buf.deque());
 
                     exchange.out_body = body;
 
@@ -468,7 +470,9 @@ impl<T> Multiplex<T> where T: Dispatch {
         Ok(())
     }
 
-    fn process_out_body_chunk(&mut self, id: RequestId, chunk: Result<Option<T::BodyOut>, T::Error>) {
+    fn process_out_body_chunk(&mut self,
+                              id: RequestId,
+                              chunk: Result<Option<T::BodyOut>, T::Error>) {
         trace!("process out body chunk; id={:?}", id);
 
         {
@@ -546,8 +550,7 @@ impl<T> Multiplex<T> where T: Dispatch {
                         id: RequestId,
                         message: Message<T::In, T::Stream>,
                         solo: bool)
-                        -> io::Result<()>
-    {
+                        -> io::Result<()> {
         let (message, body) = match message {
             Message::WithBody(message, rx) => (message, Some(rx)),
             Message::WithoutBody(message) => (message, None),
@@ -584,9 +587,7 @@ impl<T> Multiplex<T> where T: Dispatch {
             }
             Entry::Vacant(e) => {
                 // Create the exchange state
-                let mut exchange = Exchange::new(
-                    Request::In,
-                    self.frame_buf.deque());
+                let mut exchange = Exchange::new(Request::In, self.frame_buf.deque());
 
                 // Set the body receiver
                 exchange.in_body = body;
@@ -602,11 +603,7 @@ impl<T> Multiplex<T> where T: Dispatch {
         Ok(())
     }
 
-    fn write_in_error(&mut self,
-                      id: RequestId,
-                      error: T::Error)
-                      -> io::Result<()>
-    {
+    fn write_in_error(&mut self, id: RequestId, error: T::Error) -> io::Result<()> {
         if let Entry::Occupied(mut e) = self.exchanges.entry(id) {
             assert!(!e.get().responded, "exchange already responded");
 
@@ -620,7 +617,10 @@ impl<T> Multiplex<T> where T: Dispatch {
             assert!(e.get().is_complete());
 
             // Write the error frame
-            let frame = Frame::Error { id: id, error: error };
+            let frame = Frame::Error {
+                id: id,
+                error: error,
+            };
             try!(assert_send(&mut self.dispatch, frame));
             self.blocked_on_flush.wrote_frame();
 
@@ -638,8 +638,7 @@ impl<T> Multiplex<T> where T: Dispatch {
         self.scratch.clear();
 
         // Now, write the ready streams
-        'outer:
-        for (&id, exchange) in &mut self.exchanges {
+        'outer: for (&id, exchange) in &mut self.exchanges {
             trace!("   --> checking request {:?}", id);
 
             loop {
@@ -653,14 +652,20 @@ impl<T> Multiplex<T> where T: Dispatch {
                     Ok(Async::Ready(Some(chunk))) => {
                         trace!("   --> got chunk");
 
-                        let frame = Frame::Body { id: id, chunk: Some(chunk) };
+                        let frame = Frame::Body {
+                            id: id,
+                            chunk: Some(chunk),
+                        };
                         try!(assert_send(&mut self.dispatch, frame));
                         self.blocked_on_flush.wrote_frame();
                     }
                     Ok(Async::Ready(None)) => {
                         trace!("   --> end of stream");
 
-                        let frame = Frame::Body { id: id, chunk: None };
+                        let frame = Frame::Body {
+                            id: id,
+                            chunk: None,
+                        };
                         try!(assert_send(&mut self.dispatch, frame));
                         self.blocked_on_flush.wrote_frame();
 
@@ -672,7 +677,10 @@ impl<T> Multiplex<T> where T: Dispatch {
                         trace!("   --> got error");
 
                         // Write the error frame
-                        let frame = Frame::Error { id: id, error: error };
+                        let frame = Frame::Error {
+                            id: id,
+                            error: error,
+                        };
                         try!(assert_send(&mut self.dispatch, frame));
                         self.blocked_on_flush.wrote_frame();
 
@@ -733,7 +741,7 @@ impl<T> Multiplex<T> where T: Dispatch {
 }
 
 impl<T> Future for Multiplex<T>
-    where T: Dispatch,
+    where T: Dispatch
 {
     type Item = ();
     type Error = io::Error;
@@ -808,7 +816,9 @@ impl<T: Dispatch> Drop for Multiplex<T> {
 }
 
 impl<T: Dispatch> Exchange<T> {
-    fn new(request: Request<T>, deque: FrameDeque<Option<Result<T::BodyOut, T::Error>>>) -> Exchange<T> {
+    fn new(request: Request<T>,
+           deque: FrameDeque<Option<Result<T::BodyOut, T::Error>>>)
+           -> Exchange<T> {
         Exchange {
             request: request,
             responded: false,
@@ -841,10 +851,8 @@ impl<T: Dispatch> Exchange<T> {
     fn is_complete(&self) -> bool {
         // The exchange is completed if the response has been seen and bodies
         // in both directions are fully flushed
-        self.responded &&
-            self.out_body.is_none() &&
-            self.in_body.is_none() &&
-            self.request.is_none()
+        self.responded && self.out_body.is_none() && self.in_body.is_none() &&
+        self.request.is_none()
     }
 
     fn set_expect_response(&mut self, solo: bool) {
@@ -879,7 +887,7 @@ impl<T: Dispatch> Exchange<T> {
         {
             let sender = match self.out_body {
                 Some(ref mut v) => v,
-                _ =>  {
+                _ => {
                     return;
                 }
             };
@@ -938,7 +946,8 @@ impl<T: Dispatch> Exchange<T> {
             let sender = match self.out_body {
                 Some(ref mut sender) => sender,
                 None => {
-                    assert!(self.out_deque.is_empty(), "pending out frames but no sender");
+                    assert!(self.out_deque.is_empty(),
+                            "pending out frames but no sender");
                     return Ok(());
                 }
             };
@@ -983,7 +992,7 @@ impl<T: Dispatch> Exchange<T> {
                 }
 
                 if done {
-                    break
+                    break;
                 }
             }
         }
@@ -1033,11 +1042,9 @@ fn assert_send<T>(s: &mut T, item: T::SinkItem) -> Result<(), T::SinkError>
     }
 }
 
-/*
- *
- * ===== impl MultiplexMessage =====
- *
- */
+// ===== impl MultiplexMessage =====
+//
+//
 
 impl<T, B, E> MultiplexMessage<T, B, E> {
     /// Create a new MultiplexMessage
@@ -1063,9 +1070,7 @@ impl<T: Dispatch> Sink for DispatchSink<T> {
     type SinkItem = <T::Transport as Sink>::SinkItem;
     type SinkError = io::Error;
 
-    fn start_send(&mut self, item: Self::SinkItem)
-                  -> StartSend<Self::SinkItem, io::Error>
-    {
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, io::Error> {
         self.inner.transport().start_send(item)
     }
 

--- a/src/streaming/multiplex/frame_buf.rs
+++ b/src/streaming/multiplex/frame_buf.rs
@@ -45,7 +45,8 @@ impl<T> FrameBuf<T> {
     pub fn with_capacity(capacity: usize) -> FrameBuf<T> {
         assert!(capacity < MAX_CAPACITY,
                 "requested frame buffer capacity too large; max={}; requested={}",
-                MAX_CAPACITY, capacity);
+                MAX_CAPACITY,
+                capacity);
 
         let inner = UnsafeCell::new(Inner::with_capacity(capacity));
         FrameBuf { inner: Rc::new(inner) }
@@ -239,7 +240,7 @@ impl<T> Inner<T> {
 
 #[cfg(test)]
 mod test {
-    use super::{FrameBuf};
+    use super::FrameBuf;
 
     #[test]
     fn test_capacity() {

--- a/src/streaming/multiplex/mod.rs
+++ b/src/streaming/multiplex/mod.rs
@@ -32,10 +32,8 @@ pub struct StreamingMultiplex<B>(B);
 /// Additional transport details relevant to streaming, multiplexed protocols.
 ///
 /// All methods added in this trait have default implementations.
-pub trait Transport<ReadBody>: 'static +
-    Stream<Error = io::Error> +
-    Sink<SinkError = io::Error>
-{
+pub trait Transport<ReadBody>
+    : 'static + Stream<Error = io::Error> + Sink<SinkError = io::Error> {
     /// Allow the transport to do miscellaneous work (e.g., sending ping-pong
     /// messages) that is not directly connected to sending or receiving frames.
     ///
@@ -64,4 +62,4 @@ pub trait Transport<ReadBody>: 'static +
     }
 }
 
-impl<T:Io + 'static, C: Codec + 'static, ReadBody> Transport<ReadBody> for Framed<T,C> {}
+impl<T: Io + 'static, C: Codec + 'static, ReadBody> Transport<ReadBody> for Framed<T, C> {}

--- a/src/streaming/pipeline/mod.rs
+++ b/src/streaming/pipeline/mod.rs
@@ -26,10 +26,8 @@ pub struct StreamingPipeline<B>(B);
 /// Additional transport details relevant to streaming, pipelined protocols.
 ///
 /// All methods added in this trait have default implementations.
-pub trait Transport: 'static +
-    Stream<Error = io::Error> +
-    Sink<SinkError = io::Error>
-{
+pub trait Transport
+    : 'static + Stream<Error = io::Error> + Sink<SinkError = io::Error> {
     /// Allow the transport to do miscellaneous work (e.g., sending ping-pong
     /// messages) that is not directly connected to sending or receiving frames.
     ///
@@ -43,4 +41,4 @@ pub trait Transport: 'static +
     }
 }
 
-impl<T:Io + 'static, C: Codec + 'static> Transport for Framed<T,C> {}
+impl<T: Io + 'static, C: Codec + 'static> Transport for Framed<T, C> {}

--- a/src/tcp_client.rs
+++ b/src/tcp_client.rs
@@ -38,7 +38,9 @@ pub struct Connect<Kind, P> {
     handle: Handle,
 }
 
-impl<Kind, P> Future for Connect<Kind, P> where P: BindClient<Kind, TcpStream> {
+impl<Kind, P> Future for Connect<Kind, P>
+    where P: BindClient<Kind, TcpStream>
+{
     type Item = P::BindClient;
     type Error = io::Error;
 
@@ -48,7 +50,9 @@ impl<Kind, P> Future for Connect<Kind, P> where P: BindClient<Kind, TcpStream> {
     }
 }
 
-impl<Kind, P> TcpClient<Kind, P> where P: BindClient<Kind, TcpStream> {
+impl<Kind, P> TcpClient<Kind, P>
+    where P: BindClient<Kind, TcpStream>
+{
     /// Create a builder for the given client protocol.
     ///
     /// To connect to a service, you need a *client protocol* implementation;
@@ -56,7 +60,7 @@ impl<Kind, P> TcpClient<Kind, P> where P: BindClient<Kind, TcpStream> {
     pub fn new(protocol: P) -> TcpClient<Kind, P> {
         TcpClient {
             _kind: PhantomData,
-            proto: Arc::new(protocol)
+            proto: Arc::new(protocol),
         }
     }
 

--- a/src/util/client_proxy.rs
+++ b/src/util/client_proxy.rs
@@ -25,9 +25,7 @@ pub struct ClientProxy<R, S, E> {
 
 impl<R, S, E> Clone for ClientProxy<R, S, E> {
     fn clone(&self) -> Self {
-        ClientProxy {
-            tx: self.tx.clone(),
-        }
+        ClientProxy { tx: self.tx.clone() }
     }
 }
 
@@ -68,8 +66,7 @@ impl<R, S, E: From<io::Error>> Service for ClientProxy<R, S, E> {
         let (tx, rx) = oneshot::channel();
 
         // TODO: handle error
-        match mpsc::UnboundedSender::send(&mut self.tx,
-                                          Ok((request, tx))) {
+        match mpsc::UnboundedSender::send(&mut self.tx, Ok((request, tx))) {
             Ok(()) => {}
             Err(_) => panic!("receiving end of client is gone"),
         }
@@ -79,7 +76,7 @@ impl<R, S, E: From<io::Error>> Service for ClientProxy<R, S, E> {
 }
 
 impl<T, E> Future for Response<T, E>
-    where E: From<io::Error>,
+    where E: From<io::Error>
 {
     type Item = T;
     type Error = E;

--- a/tests/simple_client_proto.rs
+++ b/tests/simple_client_proto.rs
@@ -6,7 +6,7 @@ extern crate tokio_service;
 use std::str;
 use std::io::{self, ErrorKind, Write};
 
-use futures::{Future};
+use futures::Future;
 use tokio_core::io::{Io, Codec, Framed, EasyBuf};
 use tokio_core::reactor::Core;
 use tokio_proto::pipeline::ClientProto;
@@ -20,10 +20,9 @@ use tokio_proto::TcpClient;
 pub struct IntCodec;
 
 fn parse_u64(from: &[u8]) -> Result<u64, io::Error> {
-    Ok(str::from_utf8(from)
-       .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?
-       .parse()
-       .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?)
+    Ok(str::from_utf8(from).map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?
+        .parse()
+        .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?)
 }
 
 impl Codec for IntCodec {
@@ -75,8 +74,7 @@ impl<T: Io + 'static> ClientProto<T> for IntProto {
     }
 }
 
-fn is_clone<T: Clone>(_: &T) {
-}
+fn is_clone<T: Clone>(_: &T) {}
 
 #[test]
 fn test_clone() {
@@ -84,7 +82,8 @@ fn test_clone() {
     if false {
         let core = Core::new().unwrap();
         let builder = TcpClient::new(IntProto);
-        let service = builder.connect(&"127.0.0.1:12345".parse().unwrap(), &core.handle()).wait().unwrap();
+        let service =
+            builder.connect(&"127.0.0.1:12345".parse().unwrap(), &core.handle()).wait().unwrap();
         is_clone(&service);
     }
 }

--- a/tests/simple_framed.rs
+++ b/tests/simple_framed.rs
@@ -4,7 +4,7 @@ extern crate tokio_proto;
 extern crate tokio_service;
 
 use std::io;
-use futures::{BoxFuture};
+use futures::BoxFuture;
 use tokio_core::io::{Io, Codec, Framed, EasyBuf};
 use tokio_proto::TcpServer;
 use tokio_proto::streaming::{Message, Body};
@@ -96,8 +96,7 @@ fn test_streaming_pipeline_framed() {
     // Don't want this to run, only compile
     if false {
         let addr = "0.0.0.0:12345".parse().unwrap();
-        TcpServer::new(PipelineProto, addr)
-            .serve(|| Ok(TestService));
+        TcpServer::new(PipelineProto, addr).serve(|| Ok(TestService));
     }
 }
 
@@ -107,7 +106,6 @@ fn test_streaming_multiplex_framed() {
     // Don't want this to run, only compile
     if false {
         let addr = "0.0.0.0:12345".parse().unwrap();
-        TcpServer::new(MultiplexProto, addr)
-            .serve(|| Ok(TestService));
+        TcpServer::new(MultiplexProto, addr).serve(|| Ok(TestService));
     }
 }

--- a/tests/support/mock.rs
+++ b/tests/support/mock.rs
@@ -27,7 +27,7 @@ struct MockProtocol<T>(RefCell<Option<MockTransport<T>>>);
 impl<T, U, I> pipeline::ClientProto<I> for MockProtocol<pipeline::Frame<T, U, io::Error>>
     where T: 'static,
           U: 'static,
-          I: Io + 'static,
+          I: Io + 'static
 {
     type Request = T;
     type RequestBody = U;
@@ -37,7 +37,8 @@ impl<T, U, I> pipeline::ClientProto<I> for MockProtocol<pipeline::Frame<T, U, io
     type Transport = MockTransport<pipeline::Frame<T, U, io::Error>>;
     type BindTransport = Result<Self::Transport, io::Error>;
 
-    fn bind_transport(&self, _io: I)
+    fn bind_transport(&self,
+                      _io: I)
                       -> Result<MockTransport<pipeline::Frame<T, U, io::Error>>, io::Error> {
         Ok(self.0.borrow_mut().take().unwrap())
     }
@@ -46,7 +47,7 @@ impl<T, U, I> pipeline::ClientProto<I> for MockProtocol<pipeline::Frame<T, U, io
 impl<T, U, I> multiplex::ClientProto<I> for MockProtocol<multiplex::Frame<T, U, io::Error>>
     where T: 'static,
           U: 'static,
-          I: Io + 'static,
+          I: Io + 'static
 {
     type Request = T;
     type RequestBody = U;
@@ -56,7 +57,8 @@ impl<T, U, I> multiplex::ClientProto<I> for MockProtocol<multiplex::Frame<T, U, 
     type Transport = MockTransport<multiplex::Frame<T, U, io::Error>>;
     type BindTransport = Result<Self::Transport, io::Error>;
 
-    fn bind_transport(&self, _io: I)
+    fn bind_transport(&self,
+                      _io: I)
                       -> Result<MockTransport<multiplex::Frame<T, U, io::Error>>, io::Error> {
         Ok(self.0.borrow_mut().take().unwrap())
     }
@@ -65,7 +67,7 @@ impl<T, U, I> multiplex::ClientProto<I> for MockProtocol<multiplex::Frame<T, U, 
 impl<T, U, I> pipeline::ServerProto<I> for MockProtocol<pipeline::Frame<T, U, io::Error>>
     where T: 'static,
           U: 'static,
-          I: Io + 'static,
+          I: Io + 'static
 {
     type Request = T;
     type RequestBody = U;
@@ -75,7 +77,8 @@ impl<T, U, I> pipeline::ServerProto<I> for MockProtocol<pipeline::Frame<T, U, io
     type Transport = MockTransport<pipeline::Frame<T, U, io::Error>>;
     type BindTransport = Result<Self::Transport, io::Error>;
 
-    fn bind_transport(&self, _io: I)
+    fn bind_transport(&self,
+                      _io: I)
                       -> Result<MockTransport<pipeline::Frame<T, U, io::Error>>, io::Error> {
         Ok(self.0.borrow_mut().take().unwrap())
     }
@@ -84,7 +87,7 @@ impl<T, U, I> pipeline::ServerProto<I> for MockProtocol<pipeline::Frame<T, U, io
 impl<T, U, I> multiplex::ServerProto<I> for MockProtocol<multiplex::Frame<T, U, io::Error>>
     where T: 'static,
           U: 'static,
-          I: Io + 'static,
+          I: Io + 'static
 {
     type Request = T;
     type RequestBody = U;
@@ -94,7 +97,8 @@ impl<T, U, I> multiplex::ServerProto<I> for MockProtocol<multiplex::Frame<T, U, 
     type Transport = MockTransport<multiplex::Frame<T, U, io::Error>>;
     type BindTransport = Result<Self::Transport, io::Error>;
 
-    fn bind_transport(&self, _io: I)
+    fn bind_transport(&self,
+                      _io: I)
                       -> Result<MockTransport<multiplex::Frame<T, U, io::Error>>, io::Error> {
         Ok(self.0.borrow_mut().take().unwrap())
     }
@@ -190,10 +194,7 @@ fn transport<T>() -> (MockTransportCtl<T>, MockProtocol<T>) {
         tx: Some(tx2),
         rx: rx1.wait(),
     };
-    let transport = MockTransport {
-        tx: tx1,
-        rx: rx2,
-    };
+    let transport = MockTransport { tx: tx1, rx: rx2 };
     (ctl, MockProtocol(RefCell::new(Some(transport))))
 }
 
@@ -214,8 +215,7 @@ pub fn pipeline_client()
         Box<Service<Request = Message<&'static str, MockBodyStream>,
                     Response = Message<&'static str, Body<u32, io::Error>>,
                     Error = io::Error,
-                    Future = Response<Message<&'static str, Body<u32, io::Error>>,
-                                              io::Error>>>,
+                    Future = Response<Message<&'static str, Body<u32, io::Error>>, io::Error>>>,
         Box<Any>)
 {
     drop(env_logger::init());
@@ -242,11 +242,12 @@ pub fn pipeline_client()
     return (ctl, Box::new(service), Box::new(srv));
 }
 
-pub fn pipeline_server<S>(s: S)
-    -> (MockTransportCtl<pipeline::Frame<&'static str, u32, io::Error>>, Box<Any>)
+pub fn pipeline_server<S>
+    (s: S)
+     -> (MockTransportCtl<pipeline::Frame<&'static str, u32, io::Error>>, Box<Any>)
     where S: Service<Request = Message<&'static str, Body<u32, io::Error>>,
                      Response = Message<&'static str, MockBodyStream>,
-                     Error = io::Error> + Send + 'static,
+                     Error = io::Error> + Send + 'static
 {
     drop(env_logger::init());
 
@@ -273,8 +274,7 @@ pub fn multiplex_client()
         Box<Service<Request = Message<&'static str, MockBodyStream>,
                     Response = Message<&'static str, Body<u32, io::Error>>,
                     Error = io::Error,
-                    Future = Response<Message<&'static str, Body<u32, io::Error>>,
-                                              io::Error>>>,
+                    Future = Response<Message<&'static str, Body<u32, io::Error>>, io::Error>>>,
         Box<Any>)
 {
     drop(env_logger::init());
@@ -301,11 +301,12 @@ pub fn multiplex_client()
     return (ctl, Box::new(service), Box::new(srv));
 }
 
-pub fn multiplex_server<S>(s: S)
-    -> (MockTransportCtl<multiplex::Frame<&'static str, u32, io::Error>>, Box<Any>)
+pub fn multiplex_server<S>
+    (s: S)
+     -> (MockTransportCtl<multiplex::Frame<&'static str, u32, io::Error>>, Box<Any>)
     where S: Service<Request = Message<&'static str, Body<u32, io::Error>>,
                      Response = Message<&'static str, MockBodyStream>,
-                     Error = io::Error> + Send + 'static,
+                     Error = io::Error> + Send + 'static
 {
     drop(env_logger::init());
 

--- a/tests/support/service.rs
+++ b/tests/support/service.rs
@@ -7,24 +7,22 @@ use self::futures::{Future, IntoFuture};
 use self::tokio_service::Service;
 
 pub struct SimpleService<T, U> {
-    inner: Box<Fn(T) -> Box<Future<Item=U, Error=io::Error> + Send> + Send>,
+    inner: Box<Fn(T) -> Box<Future<Item = U, Error = io::Error> + Send> + Send>,
 }
 
 /// Returns a `Service` backed by the given closure.
 pub fn simple_service<F, R, T, U>(f: F) -> SimpleService<T, U>
     where F: Fn(T) -> R + Send + 'static,
-          R: IntoFuture<Item=U, Error=io::Error>,
-          R::Future: Send + 'static,
+          R: IntoFuture<Item = U, Error = io::Error>,
+          R::Future: Send + 'static
 {
-    SimpleService {
-        inner: Box::new(move |t| Box::new(f(t).into_future())),
-    }
+    SimpleService { inner: Box::new(move |t| Box::new(f(t).into_future())) }
 }
 
 impl<T, U> Service for SimpleService<T, U> {
     type Request = T;
     type Response = U;
-    type Future = Box<Future<Item=U, Error=io::Error> + Send>;
+    type Future = Box<Future<Item = U, Error = io::Error> + Send>;
     type Error = io::Error;
 
     fn call(&mut self, t: T) -> Self::Future {

--- a/tests/test_multiplex_client.rs
+++ b/tests/test_multiplex_client.rs
@@ -12,8 +12,8 @@ extern crate env_logger;
 
 use std::io;
 
-use futures::stream::{Stream};
-use futures::{Future};
+use futures::stream::Stream;
+use futures::Future;
 use tokio_proto::streaming::Message;
 use tokio_proto::streaming::multiplex::{RequestId, Frame};
 use tokio_service::Service;

--- a/tests/test_multiplex_deadlock.rs
+++ b/tests/test_multiplex_deadlock.rs
@@ -1,122 +1,121 @@
-/*
-extern crate futures;
-extern crate tokio_core;
-extern crate tokio_proto;
-extern crate tokio_service;
-extern crate rand;
-
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-
-mod support;
-
-use support::multiplex as mux;
-use support::FnService;
-
-use tokio_proto::streaming::Message;
-use tokio_proto::streaming::multiplex::{self, Frame};
-use futures::{stream, Async, Poll};
-use std::io;
-
-#[test]
-fn test_write_requires_flush() {
-
-    // Create a custom Transport middleware that requires a flush before
-    // enabling reading
-
-    struct Transport<T: multiplex::Transport> {
-        upstream: T,
-        buffer: Option<Frame<T::In, T::BodyIn, T::Error>>,
-    }
-
-    impl<T: multiplex::Transport> Transport<T> {
-        fn new(upstream: T) -> Transport<T> {
-            Transport {
-                upstream: upstream,
-                buffer: None,
-            }
-        }
-    }
-
-    impl<T> multiplex::Transport for Transport<T>
-        where T: multiplex::Transport,
-    {
-        type In = T::In;
-        type Out = T::Out;
-        type BodyIn = T::BodyIn;
-        type BodyOut = T::BodyOut;
-        type Error = T::Error;
-
-        fn poll_read(&mut self) -> Async<()> {
-            self.upstream.poll_read()
-        }
-
-        fn read(&mut self) -> Poll<Frame<Self::Out, Self::BodyOut, Self::Error>, io::Error> {
-            self.upstream.read()
-        }
-
-        fn poll_write(&mut self) -> Async<()> {
-            if self.buffer.is_none() {
-                return Async::Ready(());
-            }
-
-            Async::NotReady
-        }
-
-        fn write(&mut self, message: Frame<Self::In, Self::BodyIn, Self::Error>) -> Poll<(), io::Error> {
-            assert!(self.poll_write().is_ready());
-            self.buffer = Some(message);
-            Ok(Async::Ready(()))
-        }
-
-        fn flush(&mut self) -> Poll<(), io::Error> {
-            if self.buffer.is_some() {
-                if !self.upstream.poll_write().is_ready() {
-                    return Ok(Async::NotReady);
-                }
-
-                let msg = self.buffer.take().unwrap();
-                try!(self.upstream.write(msg));
-            }
-
-            self.upstream.flush()
-        }
-    }
-
-    // Define a simple service that just finishes immediately
-    let service = simple_service(|_| {
-        let body = vec![0, 1, 2].into_iter().map(Ok);
-        let body: mux::BodyBox = Box::new(stream::iter(body));
-
-        let resp = Message::WithBody("goodbye", body);
-
-        futures::finished(resp)
-    });
-
-    // Expect a ping pong
-    mux::run_with_transport(service, Transport::new, |mock| {
-        mock.allow_write();
-        mock.send(mux::message(0, "hello"));
-
-        let wr = mock.next_write();
-        assert_eq!(wr.request_id(), Some(0));
-        assert_eq!(wr.unwrap_msg(), "goodbye");
-
-        for i in 0..3 {
-            mock.allow_write();
-            let wr = mock.next_write();
-            assert_eq!(wr.request_id(), Some(0));
-            assert_eq!(wr.unwrap_body(), Some(i));
-        }
-
-        mock.allow_write();
-        let wr = mock.next_write();
-        assert_eq!(wr.request_id(), Some(0));
-        assert_eq!(wr.unwrap_body(), None);
-
-        mock.send(Frame::Done);
-        mock.allow_and_assert_drop();
-    });
-}
-*/
+// extern crate futures;
+// extern crate tokio_core;
+// extern crate tokio_proto;
+// extern crate tokio_service;
+// extern crate rand;
+//
+// #[macro_use]
+// extern crate log;
+// extern crate env_logger;
+//
+// mod support;
+//
+// use support::multiplex as mux;
+// use support::FnService;
+//
+// use tokio_proto::streaming::Message;
+// use tokio_proto::streaming::multiplex::{self, Frame};
+// use futures::{stream, Async, Poll};
+// use std::io;
+//
+// #[test]
+// fn test_write_requires_flush() {
+//
+// Create a custom Transport middleware that requires a flush before
+// enabling reading
+//
+// struct Transport<T: multiplex::Transport> {
+// upstream: T,
+// buffer: Option<Frame<T::In, T::BodyIn, T::Error>>,
+// }
+//
+// impl<T: multiplex::Transport> Transport<T> {
+// fn new(upstream: T) -> Transport<T> {
+// Transport {
+// upstream: upstream,
+// buffer: None,
+// }
+// }
+// }
+//
+// impl<T> multiplex::Transport for Transport<T>
+// where T: multiplex::Transport,
+// {
+// type In = T::In;
+// type Out = T::Out;
+// type BodyIn = T::BodyIn;
+// type BodyOut = T::BodyOut;
+// type Error = T::Error;
+//
+// fn poll_read(&mut self) -> Async<()> {
+// self.upstream.poll_read()
+// }
+//
+// fn read(&mut self) -> Poll<Frame<Self::Out, Self::BodyOut, Self::Error>, io::Error> {
+// self.upstream.read()
+// }
+//
+// fn poll_write(&mut self) -> Async<()> {
+// if self.buffer.is_none() {
+// return Async::Ready(());
+// }
+//
+// Async::NotReady
+// }
+//
+// fn write(&mut self, message: Frame<Self::In, Self::BodyIn, Self::Error>) -> Poll<(), io::Error> {
+// assert!(self.poll_write().is_ready());
+// self.buffer = Some(message);
+// Ok(Async::Ready(()))
+// }
+//
+// fn flush(&mut self) -> Poll<(), io::Error> {
+// if self.buffer.is_some() {
+// if !self.upstream.poll_write().is_ready() {
+// return Ok(Async::NotReady);
+// }
+//
+// let msg = self.buffer.take().unwrap();
+// try!(self.upstream.write(msg));
+// }
+//
+// self.upstream.flush()
+// }
+// }
+//
+// Define a simple service that just finishes immediately
+// let service = simple_service(|_| {
+// let body = vec![0, 1, 2].into_iter().map(Ok);
+// let body: mux::BodyBox = Box::new(stream::iter(body));
+//
+// let resp = Message::WithBody("goodbye", body);
+//
+// futures::finished(resp)
+// });
+//
+// Expect a ping pong
+// mux::run_with_transport(service, Transport::new, |mock| {
+// mock.allow_write();
+// mock.send(mux::message(0, "hello"));
+//
+// let wr = mock.next_write();
+// assert_eq!(wr.request_id(), Some(0));
+// assert_eq!(wr.unwrap_msg(), "goodbye");
+//
+// for i in 0..3 {
+// mock.allow_write();
+// let wr = mock.next_write();
+// assert_eq!(wr.request_id(), Some(0));
+// assert_eq!(wr.unwrap_body(), Some(i));
+// }
+//
+// mock.allow_write();
+// let wr = mock.next_write();
+// assert_eq!(wr.request_id(), Some(0));
+// assert_eq!(wr.unwrap_body(), None);
+//
+// mock.send(Frame::Done);
+// mock.allow_and_assert_drop();
+// });
+// }
+//

--- a/tests/test_multiplex_server.rs
+++ b/tests/test_multiplex_server.rs
@@ -30,9 +30,7 @@ use support::service::simple_service;
 
 #[test]
 fn test_immediate_done() {
-    let service = simple_service(|_| {
-        future::ok(Message::WithoutBody("goodbye"))
-    });
+    let service = simple_service(|_| future::ok(Message::WithoutBody("goodbye")));
 
     let (mut mock, _other) = mock::multiplex_server(service);
     mock.allow_and_assert_drop();
@@ -208,9 +206,7 @@ fn test_multiplexing_while_transport_not_writable() {
 
 #[test]
 fn test_repeatedly_flushes_messages() {
-    let service = simple_service(move |_| {
-        future::ok(Message::WithoutBody("goodbye"))
-    });
+    let service = simple_service(move |_| future::ok(Message::WithoutBody("goodbye")));
 
     let (mut mock, _other) = mock::multiplex_server(service);
     mock.send(msg(0, "hello"));
@@ -233,7 +229,7 @@ fn test_reaching_max_in_flight_requests() {
         let fut = rx.borrow_mut().next().unwrap().unwrap();
         let fut: oneshot::Receiver<_> = fut;
         fut.map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "broken pipe"))
-           .and_then(|res| res)
+            .and_then(|res| res)
     });
 
     let mut responses = vec![];
@@ -335,11 +331,10 @@ fn test_basic_streaming_request_body_read_then_respond() {
         let mut tx = tx.clone();
 
         body.for_each(move |chunk| {
-            (&mut tx).send(chunk).unwrap();
-            Ok(())
-        }).and_then(|_| {
-            Ok(Message::WithoutBody("hi2u"))
-        })
+                (&mut tx).send(chunk).unwrap();
+                Ok(())
+            })
+            .and_then(|_| Ok(Message::WithoutBody("hi2u")))
     });
 
     let (mut mock, _other) = mock::multiplex_server(service);
@@ -348,14 +343,20 @@ fn test_basic_streaming_request_body_read_then_respond() {
     let mut rx = rx.wait();
     for i in 0..5 {
         // Send a body chunk
-        mock.send(Frame::Body { id: 2, chunk: Some(i) });
+        mock.send(Frame::Body {
+            id: 2,
+            chunk: Some(i),
+        });
 
         // Assert service processed chunk
         assert_eq!(i, rx.next().unwrap().unwrap());
     }
 
     // Send end-of-stream notification
-    mock.send(Frame::Body { id: 2, chunk: None });
+    mock.send(Frame::Body {
+        id: 2,
+        chunk: None,
+    });
 
     let wr = mock.next_write();
     assert_eq!(2, wr.request_id());
@@ -378,11 +379,10 @@ fn test_interleaving_request_body_chunks() {
         assert_eq!(req, &format!("have-body-{}", i));
 
         body.for_each(move |chunk| {
-            (&mut tx).send((i, chunk)).unwrap();
-            Ok(())
-        }).and_then(|_| {
-            Ok(Message::WithoutBody("hi2u"))
-        })
+                (&mut tx).send((i, chunk)).unwrap();
+                Ok(())
+            })
+            .and_then(|_| Ok(Message::WithoutBody("hi2u")))
     });
 
     let (mut mock, _other) = mock::multiplex_server(service);
@@ -393,29 +393,47 @@ fn test_interleaving_request_body_chunks() {
     for i in 0..5 {
         if i % 2 == 0 {
             // Send a body chunk
-            mock.send(Frame::Body { id: 2, chunk: Some(i) });
+            mock.send(Frame::Body {
+                id: 2,
+                chunk: Some(i),
+            });
             assert_eq!((0, i), rx.next().unwrap().unwrap());
 
-            mock.send(Frame::Body { id: 4, chunk: Some(i) });
+            mock.send(Frame::Body {
+                id: 4,
+                chunk: Some(i),
+            });
             assert_eq!((1, i), rx.next().unwrap().unwrap());
         } else {
-            mock.send(Frame::Body { id: 4, chunk: Some(i) });
+            mock.send(Frame::Body {
+                id: 4,
+                chunk: Some(i),
+            });
             assert_eq!((1, i), rx.next().unwrap().unwrap());
 
             // Send a body chunk
-            mock.send(Frame::Body { id: 2, chunk: Some(i) });
+            mock.send(Frame::Body {
+                id: 2,
+                chunk: Some(i),
+            });
             assert_eq!((0, i), rx.next().unwrap().unwrap());
         }
     }
 
     // Send end-of-stream notification
-    mock.send(Frame::Body { id: 2, chunk: None });
+    mock.send(Frame::Body {
+        id: 2,
+        chunk: None,
+    });
 
     let wr = mock.next_write();
     assert_eq!(2, wr.request_id());
     assert_eq!("hi2u", wr.unwrap_msg());
 
-    mock.send(Frame::Body { id: 4, chunk: None });
+    mock.send(Frame::Body {
+        id: 4,
+        chunk: None,
+    });
 
     let wr = mock.next_write();
     assert_eq!(4, wr.request_id());
@@ -426,16 +444,13 @@ fn test_interleaving_request_body_chunks() {
 }
 
 #[test]
-fn test_interleaving_response_body_chunks() {
-}
+fn test_interleaving_response_body_chunks() {}
 
 #[test]
-fn test_transport_provides_invalid_request_ids() {
-}
+fn test_transport_provides_invalid_request_ids() {}
 
 #[test]
-fn test_reaching_max_buffered_frames() {
-}
+fn test_reaching_max_buffered_frames() {}
 
 #[test]
 fn test_read_error_as_first_frame() {
@@ -457,16 +472,14 @@ fn test_read_error_as_first_frame() {
 }
 
 #[test]
-fn test_read_error_during_stream() {
-}
+fn test_read_error_during_stream() {}
 
 #[test]
 fn test_error_handling_before_message_dispatched() {
-    /*
-    let service = simple_service(|_| {
-        unimplemented!();
-    });
-    */
+    // let service = simple_service(|_| {
+    // unimplemented!();
+    // });
+    //
 }
 
 fn msg(id: RequestId, msg: &'static str) -> Frame<&'static str, u32, io::Error> {

--- a/tests/test_pipeline_client.rs
+++ b/tests/test_pipeline_client.rs
@@ -55,8 +55,7 @@ fn test_streaming_request_body() {
 
     let (mut tx, rx) = mpsc::channel(1);
 
-    let pong = service.call(Message::WithBody("ping",
-                                              rx.then(|r| r.unwrap()).boxed()));
+    let pong = service.call(Message::WithBody("ping", rx.then(|r| r.unwrap()).boxed()));
 
     assert_eq!("ping", mock.next_write().unwrap_msg());
 
@@ -76,8 +75,7 @@ fn test_streaming_request_body() {
 
 #[test]
 #[ignore]
-fn test_streaming_response_body() {
-}
+fn test_streaming_response_body() {}
 
 #[test]
 fn test_streaming_client_dropped() {
@@ -86,8 +84,7 @@ fn test_streaming_client_dropped() {
 
         let (tx, rx) = mpsc::channel(1);
 
-        let pong = service.call(Message::WithBody("ping",
-                                                  rx.then(|r| r.unwrap()).boxed()));
+        let pong = service.call(Message::WithBody("ping", rx.then(|r| r.unwrap()).boxed()));
         (tx, mock, pong, _other)
     };
 

--- a/tests/test_pipeline_server.rs
+++ b/tests/test_pipeline_server.rs
@@ -30,9 +30,7 @@ use support::mock;
 
 #[test]
 fn test_immediate_done() {
-    let service = simple_service(|_| {
-        future::ok(Message::WithoutBody("goodbye"))
-    });
+    let service = simple_service(|_| future::ok(Message::WithoutBody("goodbye")));
 
     let (mut mock, _other) = mock::pipeline_server(service);
     mock.allow_and_assert_drop();
@@ -162,9 +160,8 @@ fn test_repeatedly_flushes_messages() {
 
 #[test]
 fn test_returning_error_from_service() {
-    let service = simple_service(move |_| {
-        future::err(io::Error::new(io::ErrorKind::Other, "nope"))
-    });
+    let service =
+        simple_service(move |_| future::err(io::Error::new(io::ErrorKind::Other, "nope")));
 
     let (mut mock, _other) = mock::pipeline_server(service);
 
@@ -175,9 +172,7 @@ fn test_returning_error_from_service() {
 
 #[test]
 fn test_reading_error_frame_from_transport() {
-    let service = simple_service(move |_| {
-        future::ok(Message::WithoutBody("omg no"))
-    });
+    let service = simple_service(move |_| future::ok(Message::WithoutBody("omg no")));
 
     let (mut mock, _other) = mock::pipeline_server(service);
     mock.send(Frame::Error {
@@ -188,9 +183,7 @@ fn test_reading_error_frame_from_transport() {
 
 #[test]
 fn test_reading_io_error_from_transport() {
-    let service = simple_service(move |_| {
-        future::finished(Message::WithoutBody("omg no"))
-    });
+    let service = simple_service(move |_| future::finished(Message::WithoutBody("omg no")));
 
     let (mut mock, _other) = mock::pipeline_server(service);
     mock.error(io::Error::new(io::ErrorKind::Other, "mock transport error frame"));
@@ -351,8 +344,7 @@ fn test_pipeline_streaming_body_without_consuming() {
 
 #[test]
 #[ignore]
-fn test_transport_error_during_body_stream() {
-}
+fn test_transport_error_during_body_stream() {}
 
 #[test]
 fn test_streaming_response_body() {
@@ -383,9 +375,15 @@ fn test_streaming_response_body() {
 }
 
 fn msg(msg: &'static str) -> Frame<&'static str, u32, io::Error> {
-    Frame::Message { message: msg, body: false }
+    Frame::Message {
+        message: msg,
+        body: false,
+    }
 }
 
 fn msg_with_body(msg: &'static str) -> Frame<&'static str, u32, io::Error> {
-    Frame::Message { message: msg, body: true }
+    Frame::Message {
+        message: msg,
+        body: true,
+    }
 }


### PR DESCRIPTION
I wanted to propose doing this since it can make it easier for contributors to make sure that they're following the project's coding style.

For example, I have my editor configured to use 2 space soft tabs for rust code. If I want to contribute to tokio-proto, I have either change my editor's soft tab width, or manually format the code by hand. If the project used rustfmt, however, I could write it however I wanted and rely on rustfmt to fix my indentation.

For this PR, all formatting options were set to the default since there is no `rustfmt.toml` in the repo.

rustfmt complained about a few long lines:

```
Rustfmt failed at /Users/rodarmor/src/tokio-proto/src/simple/pipeline/server.rs:40: line exceeded maximum length (sorry)
Rustfmt failed at /Users/rodarmor/src/tokio-proto/src/simple/multiplex/client.rs:39: line exceeded maximum length (sorry)
Rustfmt failed at /Users/rodarmor/src/tokio-proto/src/simple/multiplex/server.rs:40: line exceeded maximum length (sorry)
Rustfmt failed at /Users/rodarmor/src/tokio-proto/src/simple/pipeline/client.rs:38: line exceeded maximum length (sorry)
```

What do you think? I'd be happy to add a `rustfmt.toml` and update this PR if there are formatting options that should be overridden.