### PR TITLE
Allow shutting down a TcpServer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@
 //! fn main() {
 //!     let addr = "0.0.0.0:12345".parse().unwrap();
 //!     TcpServer::new(IntProto, addr)
-//!         .serve(|| Ok(Doubler));
+//!         .serve_forever(|| Ok(Doubler));
 //! }
 //! ```
 

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -85,6 +85,7 @@ impl<Kind, P> TcpServer<Kind, P> where
 
     /// Set the number of threads running simultaneous event loops (Unix only).
     pub fn threads(&mut self, threads: usize) {
+        assert!(threads > 0);
         if cfg!(unix) {
             self.threads = threads;
         }

--- a/tests/simple_framed.rs
+++ b/tests/simple_framed.rs
@@ -4,7 +4,7 @@ extern crate tokio_proto;
 extern crate tokio_service;
 
 use std::io;
-use futures::{BoxFuture};
+use futures::BoxFuture;
 use tokio_core::io::{Io, Codec, Framed, EasyBuf};
 use tokio_proto::TcpServer;
 use tokio_proto::streaming::{Message, Body};
@@ -97,7 +97,7 @@ fn test_streaming_pipeline_framed() {
     if false {
         let addr = "0.0.0.0:12345".parse().unwrap();
         TcpServer::new(PipelineProto, addr)
-            .serve(|| Ok(TestService));
+            .serve_forever(|| Ok(TestService));
     }
 }
 
@@ -108,6 +108,6 @@ fn test_streaming_multiplex_framed() {
     if false {
         let addr = "0.0.0.0:12345".parse().unwrap();
         TcpServer::new(MultiplexProto, addr)
-            .serve(|| Ok(TestService));
+            .serve_forever(|| Ok(TestService));
     }
 }

--- a/tests/test_tcp_server.rs
+++ b/tests/test_tcp_server.rs
@@ -1,0 +1,73 @@
+// extern crate tokio_proto;
+
+// use tokio_proto::streaming::{Message, Body};
+extern crate futures;
+extern crate tokio_core;
+extern crate tokio_proto;
+extern crate tokio_service;
+
+use std::str;
+use std::io;
+
+use futures::sync::oneshot;
+use futures::{future, Future, BoxFuture};
+use tokio_core::io::{Io, Codec, Framed, EasyBuf};
+use tokio_proto::TcpServer;
+use tokio_proto::pipeline::ServerProto;
+use tokio_service::Service;
+
+#[derive(Default)]
+pub struct ByteCodec;
+
+impl Codec for ByteCodec {
+    type In = u8;
+    type Out = u8;
+
+    fn decode(&mut self, buf: &mut EasyBuf) -> Result<Option<u8>, io::Error> {
+        Ok(buf.drain_to(1).as_slice().first().cloned())
+    }
+
+    fn encode(&mut self, item: u8, into: &mut Vec<u8>) -> io::Result<()> {
+        into.push(item);
+        Ok(())
+    }
+}
+
+pub struct ByteProto;
+
+impl<T: Io + 'static> ServerProto<T> for ByteProto {
+    type Request = u8;
+    type Response = u8;
+    type Error = io::Error;
+    type Transport = Framed<T, ByteCodec>;
+    type BindTransport = Result<Self::Transport, io::Error>;
+
+    fn bind_transport(&self, io: T) -> Self::BindTransport {
+        Ok(io.framed(ByteCodec))
+    }
+}
+
+pub struct ByteEcho;
+
+impl Service for ByteEcho {
+    type Request = u8;
+    type Response = u8;
+    type Error = io::Error;
+    type Future = BoxFuture<u8, io::Error>;
+
+    fn call(&self, req: u8) -> Self::Future {
+        future::finished(req).boxed()
+    }
+}
+
+#[test]
+fn test_shutdown() {
+  let addr = "127.0.0.1:0".parse().unwrap();
+  let (tx, rx) = oneshot::channel();
+  let mut server = TcpServer::new(ByteProto, addr);
+  server.threads(1);
+  let server_handle = server.serve(|| Ok(ByteEcho), rx);
+  println!("server.serve returned");
+  tx.complete(());
+  server_handle.wait().unwrap();
+}


### PR DESCRIPTION
serve() and with_handle() now take a future which tell a TcpServer when
to shut down. The functions now also return a TcpServerHandle, a future
which resolves once the server has shut down.

Also added the serve_forever() convenience method with the old behavior
of serving forever.

I implemented the simplest possible codec and proto so that I could actually
instantiate a tcp server to test shutdown. Is there a better way?

Feel free to bikeshed away on the interface here, a lot could probably be
improved.

Fixes #101