### PR TITLE
Pipeline client mut service

### DIFF
--- a/tests/test_pipeline_client.rs
+++ b/tests/test_pipeline_client.rs
@@ -109,7 +109,7 @@ fn test_streaming_client_dropped() {
 
 #[test]
 fn test_streaming_client_transport_dropped() {
-    let (mut mock, mut service, _) = mock::pipeline_client();
+    let (mut mock, service, _) = mock::pipeline_client();
     let pong = service.call(Message::WithoutBody("ping"));
 
     assert_eq!(pong.wait().unwrap_err().kind(), io::ErrorKind::BrokenPipe);


### PR DESCRIPTION
This PR contains an extra commit because it depends on the build error fix PR in #117.

This commit removes an extra `mut` that causes a build warning