### PR TITLE
Add a generic impl of streaming::pipeline::Transport

### DIFF
--- a/src/simple/pipeline/mod.rs
+++ b/src/simple/pipeline/mod.rs
@@ -21,7 +21,7 @@ mod lift {
     use std::io;
     use std::marker::PhantomData;
 
-    use streaming::pipeline::{Frame, Transport};
+    use streaming::pipeline::Frame;
     use futures::{Future, Stream, Sink, StartSend, Poll, Async, AsyncSink};
 
     // Lifts an implementation of RPC-style transport to streaming-style transport
@@ -69,10 +69,6 @@ mod lift {
             self.0.poll_complete()
         }
     }
-
-    impl<T, E: 'static> Transport for LiftTransport<T, E>
-        where T: 'static + Stream<Error = io::Error> + Sink<SinkError = io::Error>
-    {}
 
     impl<A, F, E> LiftBind<A, F, E> {
         pub fn lift(f: F) -> LiftBind<A, F, E> {

--- a/src/streaming/pipeline/mod.rs
+++ b/src/streaming/pipeline/mod.rs
@@ -4,7 +4,6 @@
 
 use std::io;
 use futures::{Stream, Sink};
-use tokio_core::io::{Io, Framed, Codec};
 
 mod frame;
 pub use self::frame::Frame;
@@ -43,4 +42,6 @@ pub trait Transport: 'static +
     }
 }
 
-impl<T:Io + 'static, C: Codec + 'static> Transport for Framed<T,C> {}
+impl<T> Transport for T where T: Stream<Error = io::Error> +
+                                 Sink<SinkError = io::Error> +
+                                 'static {}


### PR DESCRIPTION
This is necessary if the user wants to use Stream/Sink adaptors on a
Framed transport, for example `io.framed(codec).take(1)`.