### PR TITLE
Multiplex: Make RequestId generic

### DIFF
--- a/src/streaming/multiplex/frame.rs
+++ b/src/streaming/multiplex/frame.rs
@@ -1,8 +1,6 @@
-use super::RequestId;
-
 /// A multiplexed protocol frame
 #[derive(Debug, Clone)]
-pub enum Frame<T, B, E> {
+pub enum Frame<RequestId, T, B, E> {
     /// Either a request or a response.
     Message {
         /// Message exchange identifier
@@ -33,7 +31,7 @@ pub enum Frame<T, B, E> {
     },
 }
 
-impl<T, B, E> Frame<T, B, E> {
+impl<RequestId: Copy, T, B, E> Frame<RequestId, T, B, E> {
     /// Return the request ID associated with the frame.
     pub fn request_id(&self) -> RequestId {
         match *self {

--- a/src/streaming/multiplex/frame.rs
+++ b/src/streaming/multiplex/frame.rs
@@ -31,13 +31,13 @@ pub enum Frame<RequestId, T, B, E> {
     },
 }
 
-impl<RequestId: Copy, T, B, E> Frame<RequestId, T, B, E> {
+impl<RequestId: Clone, T, B, E> Frame<RequestId, T, B, E> {
     /// Return the request ID associated with the frame.
-    pub fn request_id(&self) -> RequestId {
+    pub fn request_id(&self) -> &RequestId {
         match *self {
-            Frame::Message { id, .. } => id,
-            Frame::Body { id, .. } => id,
-            Frame::Error { id, .. } => id,
+            Frame::Message { ref id, .. } => id,
+            Frame::Body { ref id, .. } => id,
+            Frame::Error { ref id, .. } => id,
         }
     }
 

--- a/src/streaming/multiplex/mod.rs
+++ b/src/streaming/multiplex/mod.rs
@@ -3,6 +3,8 @@
 //! See the crate-level docs for an overview.
 
 use std::io;
+use std::hash::Hash;
+use std::fmt::Debug;
 use futures::{Stream, Sink, Async};
 use tokio_core::io as old_io;
 use tokio_io as new_io;
@@ -18,11 +20,63 @@ pub use self::server::ServerProto;
 mod frame;
 pub use self::frame::Frame;
 
-
 pub mod advanced;
 
 /// Identifies a request / response thread
-pub type RequestId = u64;
+pub trait RequestId: Clone + Hash + Eq + Debug + 'static {}
+
+impl<T: Clone + Hash + Eq + Debug + 'static> RequestId for T {}
+
+/// Factory of `RequestIdSource` for the given `RequestId` and request type `T`.
+/// This has been implemented for `u64` with `Counter`.
+///
+/// In order to use a custom `RequestIdSource` with u64, you must wrap the `u64`
+/// in a newtype, then implement this trait for the newtype with the correct
+/// `RequestIdSource`.
+pub trait NewRequestIdSource<Id: RequestId, T: 'static> {
+    /// Concrete type of the RequestIdSource
+    type RequestIdSource: RequestIdSource<Id, T>;
+
+    /// Returns a new `RequestIdSource`.
+    fn requestid_source() -> Self::RequestIdSource;
+}
+
+/// `RequestIdSource` is used to generate at minimum session-wide unique identifiers of type
+/// `RequestId`. Uniqueness needs depend on the application and can be wider than single session.
+///
+/// Depending on the protocol the identifier can be generated or embedded in the message `T`.
+pub trait RequestIdSource<Id, T>: 'static {
+    /// Generate the next request id or look it up from the message
+    fn next(&mut self, msg: &T) -> Id;
+}
+
+/// `RequestIdSource` generated from by an u64 counter
+#[derive(Debug)]
+pub struct Counter(u64);
+
+impl Counter {
+    /// Initialize the counter with value 0
+    pub fn new() -> Self {
+        Counter(0)
+    }
+}
+
+impl<T: 'static> NewRequestIdSource<u64, T> for u64 {
+    type RequestIdSource = Counter;
+
+    fn requestid_source() -> Self::RequestIdSource {
+        Counter::new()
+    }
+}
+
+impl<T> RequestIdSource<u64, T> for Counter {
+    fn next(&mut self, _: &T) -> u64 {
+        let ret = self.0;
+        self.0 += 1;
+        ret
+    }
+}
+
 
 /// A marker used to flag protocols as being streaming and multiplexed.
 ///
@@ -34,7 +88,7 @@ pub struct StreamingMultiplex<B>(B);
 /// Additional transport details relevant to streaming, multiplexed protocols.
 ///
 /// All methods added in this trait have default implementations.
-pub trait Transport<ReadBody>: 'static +
+pub trait Transport<RequestId, ReadBody>: 'static +
     Stream<Error = io::Error> +
     Sink<SinkError = io::Error>
 {
@@ -66,12 +120,12 @@ pub trait Transport<ReadBody>: 'static +
     }
 }
 
-impl<T, C, ReadBody> Transport<ReadBody> for old_io::Framed<T,C>
+impl<T, C, RequestId, ReadBody> Transport<RequestId, ReadBody> for old_io::Framed<T,C>
     where T: old_io::Io + 'static,
           C: old_io::Codec + 'static,
 {}
 
-impl<T, C, ReadBody> Transport<ReadBody> for new_io::codec::Framed<T,C>
+impl<T, C, RequestId, ReadBody> Transport<RequestId, ReadBody> for new_io::codec::Framed<T,C>
     where T: new_io::AsyncRead + new_io::AsyncWrite + 'static,
           C: new_io::codec::Encoder<Error=io::Error> +
                 new_io::codec::Decoder<Error=io::Error> + 'static,

--- a/tests/simple_framed.rs
+++ b/tests/simple_framed.rs
@@ -42,7 +42,7 @@ impl Encoder for PipelineCodec {
 struct MultiplexCodec;
 
 impl Decoder for MultiplexCodec {
-    type Item = multiplex::Frame<u32, (), io::Error>;
+    type Item = multiplex::Frame<u64, u32, (), io::Error>;
     type Error = io::Error;
 
     fn decode(&mut self, _: &mut BytesMut) -> io::Result<Option<Self::Item>> {
@@ -51,7 +51,7 @@ impl Decoder for MultiplexCodec {
 }
 
 impl Encoder for MultiplexCodec {
-    type Item = multiplex::Frame<u32, u32, io::Error>;
+    type Item = multiplex::Frame<u64, u32, u32, io::Error>;
     type Error = io::Error;
 
     fn encode(&mut self, _: Self::Item, _: &mut BytesMut) -> io::Result<()> {
@@ -83,6 +83,7 @@ impl<T: AsyncRead + AsyncWrite + 'static> multiplex::ServerProto<T> for Multiple
     type Response = u32;
     type Error = io::Error;
     type ResponseBody = u32;
+    type RequestId = u64;
     type Transport = Framed<T, MultiplexCodec>;
     type BindTransport = Result<Self::Transport, io::Error>;
 

--- a/tests/support/mock.rs
+++ b/tests/support/mock.rs
@@ -43,7 +43,7 @@ impl<T, U, I> pipeline::ClientProto<I> for MockProtocol<pipeline::Frame<T, U, io
     }
 }
 
-impl<T, U, I> multiplex::ClientProto<I> for MockProtocol<multiplex::Frame<T, U, io::Error>>
+impl<T, U, I> multiplex::ClientProto<I> for MockProtocol<multiplex::Frame<u64, T, U, io::Error>>
     where T: 'static,
           U: 'static,
           I: Io + 'static,
@@ -52,12 +52,13 @@ impl<T, U, I> multiplex::ClientProto<I> for MockProtocol<multiplex::Frame<T, U, 
     type RequestBody = U;
     type Response = T;
     type ResponseBody = U;
+    type RequestId = u64;
     type Error = io::Error;
-    type Transport = MockTransport<multiplex::Frame<T, U, io::Error>>;
+    type Transport = MockTransport<multiplex::Frame<u64, T, U, io::Error>>;
     type BindTransport = Result<Self::Transport, io::Error>;
 
     fn bind_transport(&self, _io: I)
-                      -> Result<MockTransport<multiplex::Frame<T, U, io::Error>>, io::Error> {
+                      -> Result<MockTransport<multiplex::Frame<u64, T, U, io::Error>>, io::Error> {
         Ok(self.0.borrow_mut().take().unwrap())
     }
 }
@@ -81,7 +82,7 @@ impl<T, U, I> pipeline::ServerProto<I> for MockProtocol<pipeline::Frame<T, U, io
     }
 }
 
-impl<T, U, I> multiplex::ServerProto<I> for MockProtocol<multiplex::Frame<T, U, io::Error>>
+impl<T, U, I> multiplex::ServerProto<I> for MockProtocol<multiplex::Frame<u64, T, U, io::Error>>
     where T: 'static,
           U: 'static,
           I: Io + 'static,
@@ -90,12 +91,13 @@ impl<T, U, I> multiplex::ServerProto<I> for MockProtocol<multiplex::Frame<T, U, 
     type RequestBody = U;
     type Response = T;
     type ResponseBody = U;
+    type RequestId = u64;
     type Error = io::Error;
-    type Transport = MockTransport<multiplex::Frame<T, U, io::Error>>;
+    type Transport = MockTransport<multiplex::Frame<u64, T, U, io::Error>>;
     type BindTransport = Result<Self::Transport, io::Error>;
 
     fn bind_transport(&self, _io: I)
-                      -> Result<MockTransport<multiplex::Frame<T, U, io::Error>>, io::Error> {
+                      -> Result<MockTransport<multiplex::Frame<u64, T, U, io::Error>>, io::Error> {
         Ok(self.0.borrow_mut().take().unwrap())
     }
 }
@@ -133,7 +135,7 @@ impl<T: 'static> Sink for MockTransport<T> {
 }
 
 impl<T: 'static> pipeline::Transport for MockTransport<T> {}
-impl<B, T: 'static> multiplex::Transport<B> for MockTransport<T> {}
+impl<B, RID, T: 'static> multiplex::Transport<RID, B> for MockTransport<T> {}
 
 struct MockIo;
 
@@ -269,7 +271,7 @@ pub fn pipeline_server<S>(s: S)
 }
 
 pub fn multiplex_client()
-    -> (MockTransportCtl<multiplex::Frame<&'static str, u32, io::Error>>,
+    -> (MockTransportCtl<multiplex::Frame<u64, &'static str, u32, io::Error>>,
         Box<Service<Request = Message<&'static str, MockBodyStream>,
                     Response = Message<&'static str, Body<u32, io::Error>>,
                     Error = io::Error,
@@ -302,7 +304,7 @@ pub fn multiplex_client()
 }
 
 pub fn multiplex_server<S>(s: S)
-    -> (MockTransportCtl<multiplex::Frame<&'static str, u32, io::Error>>, Box<Any>)
+    -> (MockTransportCtl<multiplex::Frame<u64, &'static str, u32, io::Error>>, Box<Any>)
     where S: Service<Request = Message<&'static str, Body<u32, io::Error>>,
                      Response = Message<&'static str, MockBodyStream>,
                      Error = io::Error> + Send + 'static,

--- a/tests/support/mock.rs
+++ b/tests/support/mock.rs
@@ -54,11 +54,11 @@ impl<T, U, I> multiplex::ClientProto<I> for MockProtocol<multiplex::Frame<u64, T
     type ResponseBody = U;
     type RequestId = u64;
     type Error = io::Error;
-    type Transport = MockTransport<multiplex::Frame<u64, T, U, io::Error>>;
+    type Transport = MockTransport<multiplex::Frame<Self::RequestId, T, U, io::Error>>;
     type BindTransport = Result<Self::Transport, io::Error>;
 
     fn bind_transport(&self, _io: I)
-                      -> Result<MockTransport<multiplex::Frame<u64, T, U, io::Error>>, io::Error> {
+                      -> Result<MockTransport<multiplex::Frame<Self::RequestId, T, U, io::Error>>, io::Error> {
         Ok(self.0.borrow_mut().take().unwrap())
     }
 }
@@ -93,11 +93,11 @@ impl<T, U, I> multiplex::ServerProto<I> for MockProtocol<multiplex::Frame<u64, T
     type ResponseBody = U;
     type RequestId = u64;
     type Error = io::Error;
-    type Transport = MockTransport<multiplex::Frame<u64, T, U, io::Error>>;
+    type Transport = MockTransport<multiplex::Frame<Self::RequestId, T, U, io::Error>>;
     type BindTransport = Result<Self::Transport, io::Error>;
 
     fn bind_transport(&self, _io: I)
-                      -> Result<MockTransport<multiplex::Frame<u64, T, U, io::Error>>, io::Error> {
+                      -> Result<MockTransport<multiplex::Frame<Self::RequestId, T, U, io::Error>>, io::Error> {
         Ok(self.0.borrow_mut().take().unwrap())
     }
 }

--- a/tests/test_multiplex_client.rs
+++ b/tests/test_multiplex_client.rs
@@ -15,7 +15,7 @@ use std::io;
 use futures::stream::{Stream};
 use futures::{Future};
 use tokio_proto::streaming::Message;
-use tokio_proto::streaming::multiplex::{RequestId, Frame};
+use tokio_proto::streaming::multiplex::Frame;
 use tokio_service::Service;
 
 mod support;
@@ -89,7 +89,7 @@ fn drop_client_while_streaming_body() {
     mock.allow_and_assert_drop();
 }
 
-fn msg(id: RequestId, msg: &'static str) -> Frame<&'static str, u32, io::Error> {
+fn msg(id: u64, msg: &'static str) -> Frame<u64, &'static str, u32, io::Error> {
     Frame::Message {
         id: id,
         message: msg,
@@ -98,7 +98,7 @@ fn msg(id: RequestId, msg: &'static str) -> Frame<&'static str, u32, io::Error> 
     }
 }
 
-fn msg_with_body(id: RequestId, msg: &'static str) -> Frame<&'static str, u32, io::Error> {
+fn msg_with_body(id: u64, msg: &'static str) -> Frame<u64, &'static str, u32, io::Error> {
     Frame::Message {
         id: id,
         message: msg,
@@ -107,7 +107,7 @@ fn msg_with_body(id: RequestId, msg: &'static str) -> Frame<&'static str, u32, i
     }
 }
 
-fn body(id: RequestId, body: Option<u32>) -> Frame<&'static str, u32, io::Error> {
+fn body(id: u64, body: Option<u32>) -> Frame<u64, &'static str, u32, io::Error> {
     Frame::Body {
         id: id,
         chunk: body,

--- a/tests/test_multiplex_client.rs
+++ b/tests/test_multiplex_client.rs
@@ -27,7 +27,7 @@ fn test_ping_pong_close() {
 
     let pong = service.call(Message::WithoutBody("ping"));
     let wr = mock.next_write();
-    assert_eq!(0, wr.request_id());
+    assert_eq!(&0, wr.request_id());
     assert_eq!("ping", wr.unwrap_msg());
 
     mock.send(msg(0, "pong"));
@@ -43,7 +43,7 @@ fn test_error_on_response() {
     let pong = service.call(Message::WithoutBody("ping"));
 
     let wr = mock.next_write();
-    assert_eq!(0, wr.request_id());
+    assert_eq!(&0, wr.request_id());
     assert_eq!("ping", wr.unwrap_msg());
 
     mock.send(Frame::Error {
@@ -63,7 +63,7 @@ fn drop_client_while_streaming_body() {
     let pong = service.call(Message::WithoutBody("ping"));
 
     let wr = mock.next_write();
-    assert_eq!(0, wr.request_id());
+    assert_eq!(&0, wr.request_id());
     assert_eq!("ping", wr.unwrap_msg());
 
     mock.send(msg_with_body(0, "pong"));

--- a/tests/test_multiplex_server.rs
+++ b/tests/test_multiplex_server.rs
@@ -21,7 +21,7 @@ use futures::future;
 use futures::sync::oneshot;
 use futures::sync::mpsc;
 use tokio_proto::streaming::{Message, Body};
-use tokio_proto::streaming::multiplex::{Frame, RequestId};
+use tokio_proto::streaming::multiplex::Frame;
 use rand::Rng;
 
 mod support;
@@ -469,7 +469,7 @@ fn test_read_error_during_stream() {
 fn test_error_handling_before_message_dispatched() {
 }
 
-fn msg(id: RequestId, msg: &'static str) -> Frame<&'static str, u32, io::Error> {
+fn msg(id: u64, msg: &'static str) -> Frame<u64, &'static str, u32, io::Error> {
     Frame::Message {
         id: id,
         message: msg,
@@ -478,7 +478,7 @@ fn msg(id: RequestId, msg: &'static str) -> Frame<&'static str, u32, io::Error> 
     }
 }
 
-fn msg_with_body(id: RequestId, msg: &'static str) -> Frame<&'static str, u32, io::Error> {
+fn msg_with_body(id: u64, msg: &'static str) -> Frame<u64, &'static str, u32, io::Error> {
     Frame::Message {
         id: id,
         message: msg,

--- a/tests/test_multiplex_server.rs
+++ b/tests/test_multiplex_server.rs
@@ -49,7 +49,7 @@ fn test_immediate_writable_echo() {
     mock.send(msg(0, "hello"));
 
     let wr = mock.next_write();
-    assert_eq!(wr.request_id(), 0);
+    assert_eq!(wr.request_id(), &0);
     assert_eq!(wr.unwrap_msg(), "goodbye");
 
     mock.allow_and_assert_drop();
@@ -72,7 +72,7 @@ fn test_immediate_writable_delayed_response_echo() {
     c.complete(Ok(Message::WithoutBody("goodbye")));
 
     let wr = mock.next_write();
-    assert_eq!(wr.request_id(), 0);
+    assert_eq!(wr.request_id(), &0);
     assert_eq!(wr.unwrap_msg(), "goodbye");
 
     mock.allow_and_assert_drop();
@@ -91,7 +91,7 @@ fn test_delayed_writable_immediate_response_echo() {
     thread::sleep(Duration::from_millis(20));
 
     let wr = mock.next_write();
-    assert_eq!(wr.request_id(), 0);
+    assert_eq!(wr.request_id(), &0);
     assert_eq!(wr.unwrap_msg(), "goodbye");
 }
 
@@ -126,15 +126,15 @@ fn test_same_order_multiplexing() {
     c3.complete(Ok(Message::WithoutBody("three")));
 
     let wr = mock.next_write();
-    assert_eq!(0, wr.request_id());
+    assert_eq!(&0, wr.request_id());
     assert_eq!("one", wr.unwrap_msg());
 
     let wr = mock.next_write();
-    assert_eq!(1, wr.request_id());
+    assert_eq!(&1, wr.request_id());
     assert_eq!("two", wr.unwrap_msg());
 
     let wr = mock.next_write();
-    assert_eq!(2, wr.request_id());
+    assert_eq!(&2, wr.request_id());
     assert_eq!("three", wr.unwrap_msg());
 }
 
@@ -163,20 +163,20 @@ fn test_out_of_order_multiplexing() {
     c3.complete(Ok(Message::WithoutBody("three")));
 
     let wr = mock.next_write();
-    assert_eq!(2, wr.request_id());
+    assert_eq!(&2, wr.request_id());
     assert_eq!("three", wr.unwrap_msg());
 
     c2.complete(Ok(Message::WithoutBody("two")));
 
     let wr = mock.next_write();
-    assert_eq!(1, wr.request_id());
+    assert_eq!(&1, wr.request_id());
     assert_eq!("two", wr.unwrap_msg());
 
 
     c1.complete(Ok(Message::WithoutBody("one")));
 
     let wr = mock.next_write();
-    assert_eq!(0, wr.request_id());
+    assert_eq!(&0, wr.request_id());
     assert_eq!("one", wr.unwrap_msg());
 }
 
@@ -262,7 +262,7 @@ fn test_reaching_max_in_flight_requests() {
 
     // Read the response
     let wr = mock.next_write();
-    assert_eq!(i, wr.request_id());
+    assert_eq!(&i, wr.request_id());
     assert_eq!("zomg", wr.unwrap_msg());
 
     // Next request is processed
@@ -275,7 +275,7 @@ fn test_reaching_max_in_flight_requests() {
         c.complete((Ok(Message::WithoutBody("zomg"))));
 
         let wr = mock.next_write();
-        assert_eq!(i, wr.request_id());
+        assert_eq!(&i, wr.request_id());
         assert_eq!("zomg", wr.unwrap_msg());
     }
 
@@ -299,25 +299,25 @@ fn test_basic_streaming_response_body() {
     mock.send(msg(3, "want-body"));
 
     let wr = mock.next_write();
-    assert_eq!(3, wr.request_id());
+    assert_eq!(&3, wr.request_id());
     assert_eq!(wr.unwrap_msg(), "hi2u");
 
     // Allow the write, then send the message
     let tx = tx.send(Ok(1)).wait().unwrap();
     let wr = mock.next_write();
-    assert_eq!(3, wr.request_id());
+    assert_eq!(&3, wr.request_id());
     assert_eq!(Some(1), wr.unwrap_body());
 
     // Send the message then allow the write
     let tx = tx.send(Ok(2)).wait().ok().unwrap();
     let wr = mock.next_write();
-    assert_eq!(3, wr.request_id());
+    assert_eq!(&3, wr.request_id());
     assert_eq!(Some(2), wr.unwrap_body());
 
     drop(tx);
 
     let wr = mock.next_write();
-    assert_eq!(3, wr.request_id());
+    assert_eq!(&3, wr.request_id());
     assert_eq!(None, wr.unwrap_body());
 
     // Alright, clean shutdown
@@ -358,7 +358,7 @@ fn test_basic_streaming_request_body_read_then_respond() {
     mock.send(Frame::Body { id: 2, chunk: None });
 
     let wr = mock.next_write();
-    assert_eq!(2, wr.request_id());
+    assert_eq!(&2, wr.request_id());
     assert_eq!("hi2u", wr.unwrap_msg());
 
     // Clean shutdown
@@ -412,13 +412,13 @@ fn test_interleaving_request_body_chunks() {
     mock.send(Frame::Body { id: 2, chunk: None });
 
     let wr = mock.next_write();
-    assert_eq!(2, wr.request_id());
+    assert_eq!(&2, wr.request_id());
     assert_eq!("hi2u", wr.unwrap_msg());
 
     mock.send(Frame::Body { id: 4, chunk: None });
 
     let wr = mock.next_write();
-    assert_eq!(4, wr.request_id());
+    assert_eq!(&4, wr.request_id());
     assert_eq!("hi2u", wr.unwrap_msg());
 
     // Clean shutdown


### PR DESCRIPTION
Fixes #129 

Summary of changes:

 * add trait `streaming::multiplex::RequestIdSource` for generating `RequestId`s
   * trait can either take the id out of the message or generate it, like `Counter`
   * refactored old incrementing `u64` counter as  `streaming::multiplex::Counter`
   * created in `streaming::multiplex::ClientProto`, typename is `RequestIds`
 * add trait `streaming::multiplex::RequestId` which is `Hash + Eq + Copy + Debug`
 * all traits and structs that depended on `RequestId` have now received associated type `RequestId`
 * tests now use `u64` explicitly as `Frame<u64, ...>`
 * `simple::multiplex::*` continues to use `u64` and `streaming::multiplex::Counter`

### Naming 

Originally I was thinking about naming the new requirements for `RequestId` as `RId` and to keep the old for backwards compatibility. In the latest commit `RId` has been removed in favor of recycling the old `RequestId` name.

The associated type for `RequestIdSouce` in `streaming::multiplex::client::ClientProto` is `RequestIds`. This could be more descriptive, open for suggestions.

### `simple::multiplex::*` using `u64` and `Counter`

I am not sure if this makes much sense, and if there are no objections I'll try to make these generic as well. This would keep the *simple* side usable even if streaming is not needed.

----

Edited to reflect latest changes (mostly naming).

- [x] Destiny of old `RequestId` and the new `RequestId`
- [x] Name of `streaming::multiplex::client::ClientProto::RequestIds` (`RequestIdSource`)
- [x] Make `simple::multiplex::*` generic as well
