### PR TITLE
Reserve BytesMut size in encode.

### DIFF
--- a/tests/simple_client_proto.rs
+++ b/tests/simple_client_proto.rs
@@ -70,7 +70,9 @@ impl Encoder for IntCodec {
     type Error = io::Error;
 
     fn encode(&mut self, item: u64, into: &mut BytesMut) -> io::Result<()> {
-        into.put(item.to_string().as_bytes());
+        let string = item.to_string();
+        into.reserve(string.as_bytes().len());
+        into.put(string.as_bytes());
         Ok(())
     }
 }


### PR DESCRIPTION
BytesMut::put panics if not enough free space is available.
As Encoder::encode should not panic, call BytesMut::reserve
before calling BytesMut::put.