### PR TITLE
Bind existing TcpStream to a client protocol

### DIFF
--- a/src/tcp_client.rs
+++ b/src/tcp_client.rs
@@ -76,6 +76,16 @@ impl<Kind, P> TcpClient<Kind, P> where P: BindClient<Kind, TcpStream> {
             handle: handle.clone(),
         }
     }
+
+    /// Bind existing `TcpStream` to a client protocol
+    ///
+    /// # Return value
+    ///
+    /// Returns a `Result` with the `Service` for interacting with the server.
+    pub fn bind_client(&self, stream: TcpStream, handle: &Handle)
+                       -> Result<P::BindClient, io::Error> {
+        Ok(self.proto.bind_client(&handle, stream))
+    }
 }
 
 impl<Kind, P> fmt::Debug for Connect<Kind, P> {


### PR DESCRIPTION
This method provides the way to use existing `TcpStream` with options set (like TCP_NODELAY), or use bind-before-connect approach. Example: 

```
use tokio_core::net::TcpStream;

TcpStream::connect(&socket_addr, &handle)
    .and_then(move |tcp_stream| {
        tcp_stream.set_nodelay(true);
        tcp_stream.set_keepalive_ms(Some(5000));

        TcpClient::new(client_protocol).bind_client(tcp_stream, &handle) 
    })
```