### PR TITLE
BoundTcpClient & updated NewService

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ slab = "0.3"
 smallvec = "0.2.0"
 take = "0.1.0"
 tokio-core = "0.1.5"
-tokio-service = "0.1"
 tokio-io = "0.1"
 
 [dev-dependencies]
@@ -38,3 +37,7 @@ env_logger = "0.3.0"
 lazycell = "0.4.0"
 mio = "0.6"
 bytes = "0.4"
+
+[dependencies.tokio-service]
+git = "https://github.com/withoutboats/tokio-service"
+branch = "new-new-service"


### PR DESCRIPTION
To pair with tokio-rs/tokio-service#22, this adapts to the new definition of `NewService` that returns a future.

Also adds `BoundTcpClient`, a tcp client bound to a particular event loop & socket address, which implements this definition of `NewService`. Can be constructed from the `TcpClient::bind` method.