### PR TITLE
Use `E: Executor` instead of `tokio_core`'s `Handle`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ exclude       = [
 ]
 
 [dependencies]
-futures = "0.1.11"
+futures = "0.1.14"
 log = "0.3.6"
 net2 = "0.2"
 rand = "0.3.14"
 slab = "0.3"
 smallvec = "0.2.0"
 take = "0.1.0"
-tokio-core = "0.1.5"
+tokio-core = "0.1.8"
 tokio-service = "0.1"
 tokio-io = "0.1"
 

--- a/src/simple/multiplex/client.rs
+++ b/src/simple/multiplex/client.rs
@@ -7,9 +7,9 @@ use std::{fmt, io};
 
 use streaming::{self, Message};
 use streaming::multiplex::StreamingMultiplex;
-use tokio_core::reactor::Handle;
 use tokio_service::Service;
 use futures::{stream, Stream, Sink, Future, IntoFuture, Poll};
+use futures::future::Executor;
 
 type MyStream<E> = stream::Empty<(), E>;
 
@@ -58,10 +58,12 @@ impl<T: 'static, P: ClientProto<T>> BindClient<Multiplex, T> for P {
 
     type BindClient = ClientService<T, P>;
 
-    fn bind_client(&self, handle: &Handle, io: T) -> Self::BindClient {
+    fn bind_client<E>(&self, executor: &E, io: T) -> Self::BindClient
+        where E: Executor<Box<Future<Item = (), Error = ()>>>,
+    {
         ClientService {
             inner: BindClient::<StreamingMultiplex<MyStream<io::Error>>, T>::bind_client(
-                LiftProto::from_ref(self), handle, io
+                LiftProto::from_ref(self), executor, io
             )
         }
     }

--- a/src/simple/multiplex/server.rs
+++ b/src/simple/multiplex/server.rs
@@ -8,9 +8,9 @@ use simple::LiftProto;
 
 use streaming::{self, Message};
 use streaming::multiplex::StreamingMultiplex;
-use tokio_core::reactor::Handle;
 use tokio_service::Service;
 use futures::{stream, Stream, Sink, Future, IntoFuture, Poll};
+use futures::future::Executor;
 
 type MyStream<E> = stream::Empty<(), E>;
 
@@ -57,13 +57,14 @@ impl<T: 'static, P: ServerProto<T>> BindServer<Multiplex, T> for P {
     type ServiceResponse = P::Response;
     type ServiceError = io::Error;
 
-    fn bind_server<S>(&self, handle: &Handle, io: T, service: S)
+    fn bind_server<S, E>(&self, executor: &E, io: T, service: S)
         where S: Service<Request = Self::ServiceRequest,
                          Response = Self::ServiceResponse,
-                         Error = Self::ServiceError> + 'static
+                         Error = Self::ServiceError> + 'static,
+              E: Executor<Box<Future<Item = (), Error = ()>>>
     {
         BindServer::<StreamingMultiplex<MyStream<io::Error>>, T>::bind_server(
-            LiftProto::from_ref(self), handle, io, LiftService(service)
+            LiftProto::from_ref(self), executor, io, LiftService(service)
         )
     }
 }

--- a/src/simple/pipeline/server.rs
+++ b/src/simple/pipeline/server.rs
@@ -8,9 +8,9 @@ use simple::LiftProto;
 
 use streaming::{self, Message};
 use streaming::pipeline::StreamingPipeline;
-use tokio_core::reactor::Handle;
 use tokio_service::Service;
 use futures::{stream, Stream, Sink, Future, IntoFuture, Poll};
+use futures::future::Executor;
 
 type MyStream<E> = stream::Empty<(), E>;
 
@@ -57,13 +57,14 @@ impl<T: 'static, P: ServerProto<T>> BindServer<Pipeline, T> for P {
     type ServiceResponse = P::Response;
     type ServiceError = io::Error;
 
-    fn bind_server<S>(&self, handle: &Handle, io: T, service: S)
+    fn bind_server<S, E>(&self, executor: &E, io: T, service: S)
         where S: Service<Request = Self::ServiceRequest,
                          Response = Self::ServiceResponse,
-                         Error = io::Error> + 'static
+                         Error = Self::ServiceError> + 'static,
+              E: Executor<Box<Future<Item = (), Error = ()>>>
     {
         BindServer::<StreamingPipeline<MyStream<io::Error>>, T>::bind_server(
-            LiftProto::from_ref(self), handle, io, LiftService(service)
+            LiftProto::from_ref(self), executor, io, LiftService(service)
         )
     }
 }

--- a/src/streaming/multiplex/server.rs
+++ b/src/streaming/multiplex/server.rs
@@ -4,9 +4,9 @@ use super::advanced::{Multiplex, MultiplexMessage};
 use BindServer;
 use streaming::{Message, Body};
 use tokio_service::Service;
-use tokio_core::reactor::Handle;
 use futures::{Future, Poll, Async};
 use futures::{IntoFuture, Stream};
+use futures::future::Executor;
 use std::io;
 
 /// A streaming, multiplexed server protocol.
@@ -76,10 +76,11 @@ impl<P, T, B> BindServer<super::StreamingMultiplex<B>, T> for P where
     type ServiceResponse = Message<P::Response, B>;
     type ServiceError = P::Error;
 
-    fn bind_server<S>(&self, handle: &Handle, io: T, service: S)
+    fn bind_server<S, E>(&self, executor: &E, io: T, service: S)
         where S: Service<Request = Self::ServiceRequest,
                          Response = Self::ServiceResponse,
-                         Error = Self::ServiceError> + 'static
+                         Error = Self::ServiceError> + 'static,
+              E: Executor<Box<Future<Item = (), Error = ()>>>
     {
         let task = self.bind_transport(io).into_future().and_then(|transport| {
             let dispatch: Dispatch<S, T, P> = Dispatch {
@@ -91,7 +92,8 @@ impl<P, T, B> BindServer<super::StreamingMultiplex<B>, T> for P where
         }).map_err(|_| ());
 
         // Spawn the multiplex dispatcher
-        handle.spawn(task)
+        executor.execute(Box::new(task))
+            .expect("failed to spawn server onto executor")
     }
 }
 


### PR DESCRIPTION
This commit moves the `BindClient` and `BindServer` traits to working with the
new `Executor` trait in the `futures` crate. The intention here is to abstract
over the ability to spawn a task and remove the hardwired dependency on
`tokio_core`, allowing `tokio-proto` to be used with other event loops and/or
reactors.

So far this takes two different strategies, for comparison:

* On `BindClient` the raw future type is exposed to avoid boxes and such.
* On `BindServer` we just box up the future and don't have to worry about types
  and such.

I don't think the signature of `BindServer` today is amenable to *not* using
trait objects unfortunately, but it seems like a resaonable tradeoff to me.
Executors like tokio-core will box up the future anyway and can eventually use
specialization to avoid double-boxing.

Technically this is a breaking change but I think in practice this won't be (and
hence we may be able to land in the 0.1 series). No other external
implementations of `Bind{Server,Client}` are expected so the signature change
should be find and the only previously provided type, `Handle`, should implement
`Executor` to continue working.