### PR TITLE
Move `rand` to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ exclude       = [
 futures = "0.1.14"
 log = "0.3.6"
 net2 = "0.2"
-rand = "0.3.14"
 slab = "0.3"
 smallvec = "0.2.0"
 take = "0.1.0"
@@ -34,7 +33,8 @@ tokio-service = "0.1"
 tokio-io = "0.1"
 
 [dev-dependencies]
+bytes = "0.4"
 env_logger = "0.3.0"
 lazycell = "0.4.0"
 mio = "0.6"
-bytes = "0.4"
+rand = "0.3.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,6 @@
 #![allow(deprecated)] // TODO remove this
 
 extern crate net2;
-extern crate rand;
 extern crate slab;
 extern crate smallvec;
 extern crate take;


### PR DESCRIPTION
It isn't actually used in the library proper, just in a test.