### PR TITLE
Fix panic when server returns more responses than expected

### DIFF
--- a/src/streaming/pipeline/advanced.rs
+++ b/src/streaming/pipeline/advanced.rs
@@ -155,10 +155,7 @@ impl<T> Pipeline<T> where T: Dispatch {
                     // will get dropped. This terminates the stream.
                     self.out_body = Some(BufferOne::new(tx));
 
-                    if let Err(e) = self.dispatch.get_mut().inner.dispatch(Ok(message)) {
-                        // TODO: Should dispatch be infallible
-                        panic!("unimplemented error handling: {:?}", e);
-                    }
+                    self.dispatch.get_mut().inner.dispatch(Ok(message))?;
                 } else {
                     trace!("read out message");
 
@@ -168,10 +165,7 @@ impl<T> Pipeline<T> where T: Dispatch {
                     // the previous body stream is dropped.
                     self.out_body = None;
 
-                    if let Err(e) = self.dispatch.get_mut().inner.dispatch(Ok(message)) {
-                        // TODO: Should dispatch be infalliable
-                        panic!("unimplemented error handling: {:?}", e);
-                    }
+                    self.dispatch.get_mut().inner.dispatch(Ok(message))?;
                 }
             }
             Some(Frame::Body { chunk }) => {


### PR DESCRIPTION
Following #107, this replaces the panic with returning an error from the pipeline future. This should, I think, result in the connection being closed.

I don't know whether this is a correct fix - can someone look over it, and then I can add a test?