### PR TITLE
Replace io::Error with generic From<io::Error>

### DIFF
--- a/examples/echo-line.rs
+++ b/examples/echo-line.rs
@@ -59,8 +59,9 @@ struct LineProto;
 impl<T: AsyncRead + AsyncWrite + 'static> ServerProto<T> for LineProto {
     type Request = String;
     type Response = String;
+    type Error = io::Error;
     type Transport = Framed<T, LineCodec>;
-    type BindTransport = Result<Self::Transport, io::Error>;
+    type BindTransport = Result<Self::Transport, Self::Error>;
 
     fn bind_transport(&self, io: T) -> Self::BindTransport {
         Ok(io.framed(LineCodec))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,8 +139,9 @@
 //! impl<T: Io + 'static> ServerProto<T> for IntProto {
 //!     type Request = u64;
 //!     type Response = u64;
+//!     type Error = io::Error;
 //!     type Transport = Framed<T, IntCodec>;
-//!     type BindTransport = Result<Self::Transport, io::Error>;
+//!     type BindTransport = Result<Self::Transport, Self::Error>;
 //!
 //!     fn bind_transport(&self, io: T) -> Self::BindTransport {
 //!         Ok(io.framed(IntCodec))

--- a/src/simple/multiplex/server.rs
+++ b/src/simple/multiplex/server.rs
@@ -29,19 +29,22 @@ pub trait ServerProto<T: 'static>: 'static {
     /// Response messages.
     type Response: 'static;
 
+    /// Error type.
+    type Error: From<io::Error>;
+
     /// The message transport, which usually take `T` as a parameter.
     ///
     /// An easy way to build a transport is to use `tokio_core::io::Framed`
     /// together with a `Codec`; in that case, the transport type is
     /// `Framed<T, YourCodec>`. See the crate docs for an example.
     type Transport: 'static +
-        Stream<Item = (RequestId, Self::Request), Error = io::Error> +
-        Sink<SinkItem = (RequestId, Self::Response), SinkError = io::Error>;
+        Stream<Item = (RequestId, Self::Request), Error = Self::Error> +
+        Sink<SinkItem = (RequestId, Self::Response), SinkError = Self::Error>;
 
     /// A future for initializing a transport from an I/O object.
     ///
     /// In simple cases, `Result<Self::Transport, Self::Error>` often suffices.
-    type BindTransport: IntoFuture<Item = Self::Transport, Error = io::Error>;
+    type BindTransport: IntoFuture<Item = Self::Transport, Error = Self::Error>;
 
     /// Build a transport from the given I/O object, using `self` for any
     /// configuration.
@@ -55,7 +58,7 @@ pub trait ServerProto<T: 'static>: 'static {
 impl<T: 'static, P: ServerProto<T>> BindServer<Multiplex, T> for P {
     type ServiceRequest = P::Request;
     type ServiceResponse = P::Response;
-    type ServiceError = io::Error;
+    type ServiceError = P::Error;
 
     fn bind_server<S, E>(&self, executor: &E, io: T, service: S)
         where S: Service<Request = Self::ServiceRequest,
@@ -63,7 +66,7 @@ impl<T: 'static, P: ServerProto<T>> BindServer<Multiplex, T> for P {
                          Error = Self::ServiceError> + 'static,
               E: Executor<Box<Future<Item = (), Error = ()>>>
     {
-        BindServer::<StreamingMultiplex<MyStream<io::Error>>, T>::bind_server(
+        BindServer::<StreamingMultiplex<MyStream<P::Error>>, T>::bind_server(
             LiftProto::from_ref(self), executor, io, LiftService(service)
         )
     }
@@ -78,10 +81,10 @@ impl<T, P> streaming::multiplex::ServerProto<T> for LiftProto<P> where
     type Response = P::Response;
     type ResponseBody = ();
 
-    type Error = io::Error;
+    type Error = P::Error;
 
-    type Transport = LiftTransport<P::Transport, io::Error>;
-    type BindTransport = LiftBind<T, <P::BindTransport as IntoFuture>::Future, io::Error>;
+    type Transport = LiftTransport<P::Transport, P::Error>;
+    type BindTransport = LiftBind<T, <P::BindTransport as IntoFuture>::Future, P::Error>;
 
     fn bind_transport(&self, io: T) -> Self::BindTransport {
         LiftBind::lift(ServerProto::bind_transport(self.lower(), io).into_future())

--- a/src/streaming/multiplex/advanced.rs
+++ b/src/streaming/multiplex/advanced.rs
@@ -188,22 +188,24 @@ pub trait Dispatch {
     /// Transport type
     type Transport: Transport<Self::BodyOut,
                               Item = Frame<Self::Out, Self::BodyOut, Self::Error>,
-                              SinkItem = Frame<Self::In, Self::BodyIn, Self::Error>>;
+                              SinkItem = Frame<Self::In, Self::BodyIn, Self::Error>,
+                              Error = Self::Error,
+                              SinkError = Self::Error>;
 
     /// Mutable reference to the transport
     fn transport(&mut self) -> &mut Self::Transport;
 
     /// Poll the next available message
-    fn poll(&mut self) -> Poll<Option<MultiplexMessage<Self::In, Self::Stream, Self::Error>>, io::Error>;
+    fn poll(&mut self) -> Poll<Option<MultiplexMessage<Self::In, Self::Stream, Self::Error>>, Self::Error>;
 
     /// The `Dispatch` is ready to accept another message
     fn poll_ready(&self) -> Async<()>;
 
     /// Process an out message
-    fn dispatch(&mut self, message: MultiplexMessage<Self::Out, Body<Self::BodyOut, Self::Error>, Self::Error>) -> io::Result<()>;
+    fn dispatch(&mut self, message: MultiplexMessage<Self::Out, Body<Self::BodyOut, Self::Error>, Self::Error>) -> Result<(), Self::Error>;
 
     /// Cancel interest in the exchange identified by RequestId
-    fn cancel(&mut self, request_id: RequestId) -> io::Result<()>;
+    fn cancel(&mut self, request_id: RequestId) -> Result<(), Self::Error>;
 }
 
 /*
@@ -244,7 +246,7 @@ impl<T> Multiplex<T> where T: Dispatch {
     }
 
     /// Attempt to dispatch any outbound request messages
-    fn flush_dispatch_deque(&mut self) -> io::Result<()> {
+    fn flush_dispatch_deque(&mut self) -> Result<(), T::Error> {
         while self.dispatch.get_mut().inner.poll_ready().is_ready() {
             let id = match self.dispatch_deque.pop_front() {
                 Some(id) => id,
@@ -300,7 +302,7 @@ impl<T> Multiplex<T> where T: Dispatch {
     }
 
     /// Read and process frames from transport
-    fn read_out_frames(&mut self) -> io::Result<()> {
+    fn read_out_frames(&mut self) -> Result<(), T::Error> {
         while self.run {
             // TODO: Only read frames if there is available space in the frame
             // buffer
@@ -317,7 +319,7 @@ impl<T> Multiplex<T> where T: Dispatch {
     /// Process outbound frame
     fn process_out_frame(&mut self,
                          frame: Option<Frame<T::Out, T::BodyOut, T::Error>>)
-                         -> io::Result<()> {
+                         -> Result<(), T::Error> {
         trace!("Multiplex::process_out_frame");
 
         match frame {
@@ -356,7 +358,7 @@ impl<T> Multiplex<T> where T: Dispatch {
                            message: Message<T::Out, Body<T::BodyOut, T::Error>>,
                            body: Option<mpsc::Sender<Result<T::BodyOut, T::Error>>>,
                            solo: bool)
-                           -> io::Result<()>
+                           -> Result<(), T::Error>
     {
         trace!("   --> process message; body={:?}", body.is_some());
 
@@ -444,7 +446,7 @@ impl<T> Multiplex<T> where T: Dispatch {
     }
 
     // Process an error
-    fn process_out_err(&mut self, id: RequestId, err: T::Error) -> io::Result<()> {
+    fn process_out_err(&mut self, id: RequestId, err: T::Error) -> Result<(), T::Error> {
         trace!("   --> process error frame");
 
         let mut remove = false;
@@ -518,13 +520,13 @@ impl<T> Multiplex<T> where T: Dispatch {
         self.exchanges.remove(&id);
     }
 
-    fn write_in_frames(&mut self) -> io::Result<()> {
+    fn write_in_frames(&mut self) -> Result<(), T::Error> {
         try!(self.write_in_messages());
         try!(self.write_in_body());
         Ok(())
     }
 
-    fn write_in_messages(&mut self) -> io::Result<()> {
+    fn write_in_messages(&mut self) -> Result<(), T::Error> {
         trace!("write in messages");
 
         while self.dispatch.poll_ready().is_ready() {
@@ -573,7 +575,7 @@ impl<T> Multiplex<T> where T: Dispatch {
                         id: RequestId,
                         message: Message<T::In, T::Stream>,
                         solo: bool)
-                        -> io::Result<()>
+                        -> Result<(), T::Error>
     {
         let (message, body) = match message {
             Message::WithBody(message, rx) => (message, Some(rx)),
@@ -632,7 +634,7 @@ impl<T> Multiplex<T> where T: Dispatch {
     fn write_in_error(&mut self,
                       id: RequestId,
                       error: T::Error)
-                      -> io::Result<()>
+                      -> Result<(), T::Error>
     {
         if let Entry::Occupied(mut e) = self.exchanges.entry(id) {
             assert!(!e.get().responded, "exchange already responded");
@@ -659,7 +661,7 @@ impl<T> Multiplex<T> where T: Dispatch {
         Ok(())
     }
 
-    fn write_in_body(&mut self) -> io::Result<()> {
+    fn write_in_body(&mut self) -> Result<(), T::Error> {
         trace!("write in body chunks");
 
         self.scratch.clear();
@@ -731,7 +733,7 @@ impl<T> Multiplex<T> where T: Dispatch {
         Ok(())
     }
 
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush(&mut self) -> Result<(), T::Error> {
         self.is_flushed = try!(self.dispatch.poll_complete()).is_ready();
 
         // TODO: Technically, poll_complete needs to be called on the exchange body senders.
@@ -763,10 +765,10 @@ impl<T> Future for Multiplex<T>
     where T: Dispatch,
 {
     type Item = ();
-    type Error = io::Error;
+    type Error = T::Error;
 
     // Tick the pipeline state machine
-    fn poll(&mut self) -> Poll<(), io::Error> {
+    fn poll(&mut self) -> Poll<(), T::Error> {
         trace!("Multiplex::tick ~~~~~~~~~~~~~~~~~~~~~~~~~~~");
 
         // Always tick the transport first
@@ -1109,19 +1111,19 @@ impl<T, B, E> MultiplexMessage<T, B, E> {
 
 impl<T: Dispatch> Sink for DispatchSink<T> {
     type SinkItem = <T::Transport as Sink>::SinkItem;
-    type SinkError = io::Error;
+    type SinkError = <T::Transport as Sink>::SinkError;
 
     fn start_send(&mut self, item: Self::SinkItem)
-                  -> StartSend<Self::SinkItem, io::Error>
+                  -> StartSend<Self::SinkItem, Self::SinkError>
     {
         self.inner.transport().start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), io::Error> {
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
         self.inner.transport().poll_complete()
     }
 
-    fn close(&mut self) -> Poll<(), io::Error> {
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
         self.inner.transport().close()
     }
 }

--- a/src/streaming/pipeline/advanced.rs
+++ b/src/streaming/pipeline/advanced.rs
@@ -64,16 +64,18 @@ pub trait Dispatch {
 
     /// Transport type
     type Transport: Transport<Item = Frame<Self::Out, Self::BodyOut, Self::Error>,
-                              SinkItem = Frame<Self::In, Self::BodyIn, Self::Error>>;
+                              Error = Self::Error,
+                              SinkItem = Frame<Self::In, Self::BodyIn, Self::Error>,
+                              SinkError = Self::Error>;
 
     /// Mutable reference to the transport
     fn transport(&mut self) -> &mut Self::Transport;
 
     /// Process an out message
-    fn dispatch(&mut self, message: PipelineMessage<Self::Out, Body<Self::BodyOut, Self::Error>, Self::Error>) -> io::Result<()>;
+    fn dispatch(&mut self, message: PipelineMessage<Self::Out, Body<Self::BodyOut, Self::Error>, Self::Error>) -> Result<(), Self::Error>;
 
     /// Poll the next completed message
-    fn poll(&mut self) -> Poll<Option<PipelineMessage<Self::In, Self::Stream, Self::Error>>, io::Error>;
+    fn poll(&mut self) -> Poll<Option<PipelineMessage<Self::In, Self::Stream, Self::Error>>, Self::Error>;
 
     /// RPC currently in flight
     /// TODO: Get rid of
@@ -110,7 +112,7 @@ impl<T> Pipeline<T> where T: Dispatch {
         !self.run && self.is_flushed && !self.has_in_flight()
     }
 
-    fn read_out_frames(&mut self) -> io::Result<()> {
+    fn read_out_frames(&mut self) -> Result<(), T::Error> {
         while self.run {
             // Return true if the pipeliner can process new outbound frames
             if !self.check_out_body_stream() {
@@ -138,7 +140,7 @@ impl<T> Pipeline<T> where T: Dispatch {
 
     fn process_out_frame(&mut self,
                          frame: Option<Frame<T::Out, T::BodyOut, T::Error>>)
-                         -> io::Result<()> {
+                         -> Result<(), T::Error> {
         trace!("process_out_frame");
         // At this point, the service & transport are ready to process the
         // frame, no matter what it is.
@@ -194,7 +196,7 @@ impl<T> Pipeline<T> where T: Dispatch {
                 // isn't much else that we can do. Killing the task
                 // will cause all in-flight requests to abort, but
                 // they can't be written to the transport anyway...
-                return Err(io::Error::new(io::ErrorKind::BrokenPipe, "An error occurred."));
+                return Err(io::Error::new(io::ErrorKind::BrokenPipe, "An error occurred.").into());
             }
         }
 
@@ -229,7 +231,7 @@ impl<T> Pipeline<T> where T: Dispatch {
         Ok(())
     }
 
-    fn write_in_frames(&mut self) -> io::Result<()> {
+    fn write_in_frames(&mut self) -> Result<(), T::Error> {
         trace!("write_in_frames");
         while self.dispatch.poll_ready().is_ready() {
             // Ensure the current in body is fully written
@@ -262,7 +264,7 @@ impl<T> Pipeline<T> where T: Dispatch {
         Ok(())
     }
 
-    fn write_in_message(&mut self, message: Result<Message<T::In, T::Stream>, T::Error>) -> io::Result<()> {
+    fn write_in_message(&mut self, message: Result<Message<T::In, T::Stream>, T::Error>) -> Result<(), T::Error> {
         trace!("write_in_message");
         match message {
             Ok(Message::WithoutBody(val)) => {
@@ -298,7 +300,7 @@ impl<T> Pipeline<T> where T: Dispatch {
     }
 
     // Returns true if the response body is fully written
-    fn write_in_body(&mut self) -> io::Result<bool> {
+    fn write_in_body(&mut self) -> Result<bool, T::Error> {
         trace!("write_in_body");
 
         if self.in_body.is_some() {
@@ -334,7 +336,7 @@ impl<T> Pipeline<T> where T: Dispatch {
         Ok(true)
     }
 
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush(&mut self) -> Result<(), T::Error> {
         self.is_flushed = try!(self.dispatch.poll_complete()).is_ready();
 
         if let Some(ref mut out_body) = self.out_body {
@@ -357,10 +359,10 @@ impl<T> Pipeline<T> where T: Dispatch {
 
 impl<T> Future for Pipeline<T> where T: Dispatch {
     type Item = ();
-    type Error = io::Error;
+    type Error = T::Error;
 
     // Tick the pipeline state machine
-    fn poll(&mut self) -> Poll<(), io::Error> {
+    fn poll(&mut self) -> Poll<(), T::Error> {
         trace!("Pipeline::tick");
 
         // Always tick the transport first
@@ -418,19 +420,19 @@ impl<T> fmt::Debug for Pipeline<T>
 
 impl<T: Dispatch> Sink for DispatchSink<T> {
     type SinkItem = <T::Transport as Sink>::SinkItem;
-    type SinkError = io::Error;
+    type SinkError = <T::Transport as Sink>::SinkError;
 
     fn start_send(&mut self, item: Self::SinkItem)
-                  -> StartSend<Self::SinkItem, io::Error>
+                  -> StartSend<Self::SinkItem, Self::SinkError>
     {
         self.inner.transport().start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), io::Error> {
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
         self.inner.transport().poll_complete()
     }
 
-    fn close(&mut self) -> Poll<(), io::Error> {
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
         self.inner.transport().close()
     }
 }

--- a/src/streaming/pipeline/mod.rs
+++ b/src/streaming/pipeline/mod.rs
@@ -28,9 +28,7 @@ pub struct StreamingPipeline<B>(B);
 /// Additional transport details relevant to streaming, pipelined protocols.
 ///
 /// All methods added in this trait have default implementations.
-pub trait Transport: 'static +
-    Stream<Error = io::Error> +
-    Sink<SinkError = io::Error>
+pub trait Transport: 'static + Stream + Sink
 {
     /// Allow the transport to do miscellaneous work (e.g., sending ping-pong
     /// messages) that is not directly connected to sending or receiving frames.
@@ -40,7 +38,7 @@ pub trait Transport: 'static +
     fn tick(&mut self) {}
 
     /// Cancel interest in the current stream
-    fn cancel(&mut self) -> io::Result<()> {
+    fn cancel(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/tests/simple_client_proto.rs
+++ b/tests/simple_client_proto.rs
@@ -84,6 +84,7 @@ pub struct IntProto;
 impl<T: AsyncRead + AsyncWrite + 'static> ClientProto<T> for IntProto {
     type Request = u64;
     type Response = u64;
+    type Error = io::Error;
     type Transport = Framed<T, IntCodec>;
     type BindTransport = Result<Self::Transport, io::Error>;
 


### PR DESCRIPTION
Allow protocols to have their own error types.